### PR TITLE
Release BidiLens 0.2.0

### DIFF
--- a/.changeset/safer-control-groups.md
+++ b/.changeset/safer-control-groups.md
@@ -1,7 +1,0 @@
----
-"@bidilens/core": minor
----
-
-Add atomic control-family sanitization, contextual invisible-character
-diagnostics, broad representative RTL-script coverage, and multiline fenced
-code recognition inside surrounding raw-text prose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project are recorded here. The complete package set
 is published under the public `@bidilens` npm scope.
 
+## 0.2.0 - 2026-07-27
+
+### Direction and security
+
+- Added representative coverage for 32 RTL scripts and linear recognition of
+  closed multiline Markdown fences inside surrounding raw-text prose.
+- Added contextual findings for identifier-like ZWNJ/ZWJ, WORD JOINER, and
+  midstream BOM while preserving ordinary Persian and emoji joining behavior.
+- Added category-selective bidi-control sanitization with atomic
+  opener/closer families and backward-compatible risk-only behavior.
+
+### Release engineering
+
+- Expanded the packed consumer to execute mixed-direction and pure-LTR
+  non-interference checks across the public adapters.
+- Added the unified `verify:production` gate and regenerated the self-contained
+  GitHub Action bundle from the hardened source.
+- Audited the sibling `v1.5-Her` implementation and documented adopted ideas,
+  rejected scope, remaining limitations, and reproducible evidence.
+
 ## 0.1.1 - 2026-07-26
 
 ### Public release

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
 repository-code: "https://github.com/CodeinScrubs/BidiLens"
 url: "https://github.com/CodeinScrubs/BidiLens"
 license: MIT
-version: 0.1.1
+version: 0.2.0
 keywords:
   - bidirectional text
   - RTL

--- a/README.fa.md
+++ b/README.fa.md
@@ -13,7 +13,7 @@
 [مشارکت](CONTRIBUTING.md) · [وضعیت پروژه](docs/V1_BUILD_REPORT.md)
 
 > [!IMPORTANT]
-> بخش وب و JavaScript به‌عنوان نسخهٔ آزمایشی عمومی `0.1.1` منتشر شده است. هر
+> بخش وب و JavaScript به‌عنوان نسخهٔ آزمایشی عمومی `0.2.0` منتشر شده است. هر
 > ۱۲ بستهٔ `@bidilens/*` در npm عمومی هستند و یکپارچگی و provenance آن‌ها
 > بررسی شده است. پلتفرم‌های بومی/دسکتاپ همچنان در نقشهٔ راه هستند.
 
@@ -73,7 +73,7 @@ The Persian word کتاب means “book”.
 - ۹۱۸ نمونهٔ اعتبارسنجی‌شده با JSON Schema و آزمون تصویری در سه موتور مرورگر.
 
 تمام بسته‌های عمومی ESM-only هستند و برای استفادهٔ سمت سرور به Node.js 22.12 یا
-جدیدتر نیاز دارند. مجموعهٔ کامل نسخهٔ `0.1.1` در
+جدیدتر نیاز دارند. مجموعهٔ کامل نسخهٔ `0.2.0` در
 [سازمان `@bidilens` در npm](https://www.npmjs.com/org/bidilens) منتشر شده است.
 
 پروژه با [مجوز MIT](LICENSE) متن‌باز است. شرایط داده‌های Unicode و بخش
@@ -88,7 +88,7 @@ Apache-2.0 پیکره در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) حف
 استفاده است:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.1.1"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.2.0"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [Project status](docs/V1_BUILD_REPORT.md)
 
 > [!IMPORTANT]
-> The JavaScript/web surface is published as the public `0.1.1` beta. All 12
+> The JavaScript/web surface is published as the public `0.2.0` beta. All 12
 > `@bidilens/*` packages are public on npm with verified registry integrity and
 > SLSA provenance. Native/desktop platforms remain explicit roadmap work rather
 > than claimed support.
@@ -133,7 +133,7 @@ reordering and shaping; BidiLens supplies the application structure they need.
 
 All public packages are ESM-only, require maintained Node.js 22.12 or newer for
 server-side use, include declarations, a package README, license, and runnable example.
-Browser packages target current standards-based browsers. The complete `0.1.1`
+Browser packages target current standards-based browsers. The complete `0.2.0`
 package set is [published under the `@bidilens` npm scope](https://www.npmjs.com/org/bidilens).
 
 ## Consumer install
@@ -149,7 +149,7 @@ For a no-build browser page, the published Web Component also exposes a
 standalone entry that bundles the core and needs no import map:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.1.1"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.2.0"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 

--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @bidilens/demo
 
-## 0.1.2
+## 0.2.0
 
 ### Patch Changes
 

--- a/apps/demo/CHANGELOG.md
+++ b/apps/demo/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @bidilens/demo
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+  - @bidilens/markdown@0.2.0
+  - @bidilens/react@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/demo",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/demo",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/V1_BUILD_REPORT.md
+++ b/docs/V1_BUILD_REPORT.md
@@ -1,8 +1,12 @@
-# BidiLens 0.1.1 reliability-patch report
+# BidiLens 0.2.0 release report
 
 **Evidence date:** 2026-07-27
 
 **License:** MIT, with Unicode-data and Apache-2.0 corpus third-party notices
+
+**0.2.0 release status:** source, package manifests, changelogs, and protected
+release gates are aligned for the minor release; registry and provenance
+evidence must be recorded only after the protected OIDC workflow succeeds
 
 **Publication status:** all 12 `0.1.1` packages are public with verified
 registry integrity and SLSA provenance; the exact source commit has an

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bidilens",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Standards-first bidirectional text tooling for AI chat, Markdown, streaming UIs, and developer tools.",
   "license": "MIT",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @bidilens/cli
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+  - @bidilens/html@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/cli",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "CLI for inspecting direction and auditing hidden Unicode bidi controls.",
   "license": "MIT",
   "author": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @bidilens/core
 
+## 0.2.0
+
+### Minor Changes
+
+- bd39a0d: Add atomic control-family sanitization, contextual invisible-character
+  diagnostics, broad representative RTL-script coverage, and multiline fenced
+  code recognition inside surrounding raw-text prose.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Unicode direction analysis, isolation, streaming state, and bidi security primitives.",
   "license": "MIT",
   "author": {

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/dom
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/dom",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "DOM annotation and streaming mutation support for bidirectional text.",
   "license": "MIT",
   "author": {

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/html
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/html",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Safe semantic HTML serialization for mixed RTL/LTR text and AI responses.",
   "license": "MIT",
   "author": {

--- a/packages/markdown/CHANGELOG.md
+++ b/packages/markdown/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/markdown
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/markdown",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Batch and streaming Markdown AST/HTML tooling for mixed RTL/LTR content.",
   "license": "MIT",
   "author": {

--- a/packages/playwright/CHANGELOG.md
+++ b/packages/playwright/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @bidilens/playwright
 
+## 0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/playwright",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Reusable Playwright assertions for mixed RTL/LTR rendering, isolation, selection, and clipboard invariants.",
   "license": "MIT",
   "author": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/react
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/react",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "React components and hooks for mixed RTL/LTR and streaming AI messages.",
   "license": "MIT",
   "author": {

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @bidilens/spec
 
+## 0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/spec",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Versioned language-neutral JSON Schemas for BidiLens analysis, security, and streaming output.",
   "license": "MIT",
   "author": {

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/svelte
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/svelte",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Svelte store adapter for bidirectional streaming messages.",
   "license": "MIT",
   "author": {

--- a/packages/terminal/CHANGELOG.md
+++ b/packages/terminal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/terminal
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/terminal",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Honest best-effort bidi formatting and diagnostics for terminals and plain-text channels.",
   "license": "MIT",
   "author": {

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/vue
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/vue",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Vue 3 bidirectional message component and composable.",
   "license": "MIT",
   "author": {

--- a/packages/web-component/CHANGELOG.md
+++ b/packages/web-component/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @bidilens/web-component
 
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [bd39a0d]
+  - @bidilens/core@0.2.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bidilens/web-component",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Framework-independent custom element for bidirectional AI messages.",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## What changed

- consume the approved `safer-control-groups` Changeset
- align all 12 public `@bidilens/*` packages and the release root manifest at `0.2.0`
- update every public package changelog
- advance the private demo to `0.1.2` for propagated workspace dependencies

## Why

The new atomic sanitizer groups are a public API addition, so the fixed public package group requires a minor version. The root version is also aligned because the protected publisher rejects a requested version that differs from the root release manifest.

## Evidence

- [x] Source/behavior PR #11 passed all 11 required CI jobs and merged to `main`.
- [x] The approved Changeset was consumed with `changeset version`.
- [x] All 12 public package manifests are exactly `0.2.0`.
- [x] `pnpm run npm:release:dry-run -- --version 0.2.0` packed all 12 packages successfully.
- [x] npm registry lookup confirms `@bidilens/core@0.2.0` is not yet published.
- [x] No product source behavior differs from the already-reviewed PR #11.

## Security and language review

This PR contains only generated release metadata and version alignment. Security, bidi-control, corpus, native-language limitation, and packed-consumer evidence are documented in PR #11. Publication remains gated by the protected `npm-release` environment, exact confirmation phrase, OIDC trusted publishing, provenance, and post-publication integrity verification.