### PR TITLE
docs: require Android CI on main

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -32,7 +32,21 @@ Android Gradle Plugin 9.2.1, compile SDK 36, and Kotlin 2.3.10.
 
 ## Use with Jetpack Compose
 
-Build the modules from this checkout once:
+For the current public release, download and extract
+[`bidilens-android-v0.1.0-maven-repository.zip`](https://github.com/CodeinScrubs/BidiLens/releases/download/android-v0.1.0/bidilens-android-v0.1.0-maven-repository.zip)
+inside your project, then point Gradle at the extracted repository:
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        maven { url = uri("$rootDir/vendor/bidilens-android-v0.1.0") }
+        google()
+        mavenCentral()
+    }
+}
+```
+
+Alternatively, build the modules from this checkout once:
 
 ```bash
 ./android/gradlew -p android publishToMavenLocal
@@ -142,11 +156,13 @@ Current executable evidence includes:
 
 ## Distribution status
 
-The native modules are source-complete and Maven-publication-ready, but their
-coordinates are not claimed as Maven Central artifacts until the first signed
-Central release exists. Today, use `publishToMavenLocal`, include the modules
-from a source checkout, or consume AARs attached to an applicable GitHub
-release. The npm packages remain a separate JavaScript/web distribution.
+The native modules are source-complete and available in the
+[`android-v0.1.0` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.0)
+as an external-consumer-tested Maven repository bundle, individual AARs, a
+sample APK, an SBOM, and SHA-256 checksums. Their coordinates are not claimed
+as Maven Central artifacts until the first signed Central release exists.
+Source checkout and `publishToMavenLocal` remain supported. The npm packages
+remain a separate JavaScript/web distribution.
 
 See the repository [limitations](../docs/LIMITATIONS.md), [architecture](../docs/ARCHITECTURE.md),
 and [security policy](../SECURITY.md) before production rollout.

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -18,6 +18,27 @@ type UiLanguage = 'en' | 'fa';
 type Theme = 'light' | 'dark';
 type PlaygroundPolicy = Extract<DetectionStrategy, 'content-majority' | 'first-strong'>;
 
+const CLIPBOARD_TIMEOUT_MS = 2_000;
+
+function settleWithin<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(
+      () => reject(new Error(`Operation exceeded ${timeoutMs}ms`)),
+      timeoutMs
+    );
+    operation.then(
+      (value) => {
+        window.clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        window.clearTimeout(timeout);
+        reject(error);
+      }
+    );
+  });
+}
+
 interface CorpusFixture {
   id: string;
   description: string;
@@ -212,7 +233,7 @@ export function App() {
     window.history.replaceState(null, '', target);
     if (navigator.clipboard?.writeText) {
       try {
-        await navigator.clipboard.writeText(target.href);
+        await settleWithin(navigator.clipboard.writeText(target.href), CLIPBOARD_TIMEOUT_MS);
         setActionStatus(t.shareCopied);
         return;
       } catch {
@@ -260,8 +281,8 @@ export function App() {
     }
     if (navigator.clipboard?.writeText && navigator.clipboard?.readText) {
       try {
-        await navigator.clipboard.writeText(markdown);
-        const copied = await navigator.clipboard.readText();
+        await settleWithin(navigator.clipboard.writeText(markdown), CLIPBOARD_TIMEOUT_MS);
+        const copied = await settleWithin(navigator.clipboard.readText(), CLIPBOARD_TIMEOUT_MS);
         setActionStatus(copied === markdown ? t.copyPassed : t.copyFailed);
         return;
       } catch {

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -9,8 +9,12 @@ required for future releases.
 
 The Android modules under `android/` are configured as Maven publications and
 can be verified with `./android/gradlew -p android publishToMavenLocal`.
-Release AARs and sources jars are built by CI. They must not be described as
-Maven Central artifacts until all of the following are complete:
+Release AARs and sources jars are built by CI. The verified
+[`android-v0.1.0` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.0)
+contains the CI AARs, an external-consumer-tested Maven repository bundle, a
+sample APK, an SBOM, and SHA-256 checksums tied to commit `85b80c0`. These
+artifacts must not be described as Maven Central artifacts until all of the
+following are complete:
 
 - Central namespace ownership for `io.github.codeinscrubs.bidilens`;
 - GPG/signing material managed outside the repository;

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -31,7 +31,8 @@ registry publication.
 - verified `shayanay80` owner access to the `bidilens` npm organization and
   `@bidilens` scope;
 - identified bootstrap maintainer and CODEOWNERS;
-- strict `main` protection requires all 11 CI job contexts on an up-to-date
+- strict `main` protection requires all 13 CI job contexts, including the
+  Android library/sample build and API 35 UI-test gate, on an up-to-date
   branch and linear history, while blocking force-pushes, branch deletion, and
   unresolved review conversations; the sole-maintainer administrative bypass
   remains available for CI-outage recovery;

--- a/tests/visual/demo.spec.ts
+++ b/tests/visual/demo.spec.ts
@@ -6,6 +6,32 @@ const DEMO_ORIGIN = 'http://127.0.0.1:4173';
 const FLAGSHIP = 'React یک کتابخانه جاوااسکریپت بسیار محبوب است.';
 const SHARED = 'The Persian word کتاب means “book”.';
 
+test('falls back when the browser clipboard API never settles', async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        readText: () => new Promise<string>(() => undefined),
+        writeText: () => new Promise<void>(() => undefined)
+      }
+    });
+  });
+  await page.goto(DEMO_ORIGIN);
+  await page.getByLabel('Load a mixed-direction preset').selectOption('flagship');
+
+  const status = page.locator('.action-status');
+  await page.getByRole('button', { name: 'Copy share link' }).click();
+  await expect(status).toHaveText('Share state added to the address bar; copy the URL manually.', {
+    timeout: 5_000
+  });
+
+  await page.getByRole('button', { name: 'Verify logical copy' }).click();
+  await expect(status).toHaveText(
+    'Logical selection matches the immutable source; clipboard readback is unavailable.',
+    { timeout: 5_000 }
+  );
+});
+
 test('exercises the offline bilingual playground, controls, corpus, copy, and exports', async ({ page }) => {
   const initialHash = new URLSearchParams({ text: SHARED }).toString();
   await page.goto(`${DEMO_ORIGIN}/#${initialHash}`);


### PR DESCRIPTION
## What changed

- Document that strict `main` protection now requires both Android CI contexts in addition to the existing eleven checks.
- Link the public `android-v0.1.0` release and document how to consume its Maven repository bundle.
- Record the exact Android release artifacts and the honest Maven Central boundary.
- Bound demo clipboard reads/writes so browsers with a stalled Clipboard API fall back instead of hanging, with a deterministic three-browser regression test.

## Evidence

- [x] Repository protection re-read through the GitHub API: strict mode and 13 required contexts, including `Android libraries and sample` and `Android UI tests (API 35)`.
- [x] Exact Android source commit `85b80c0` passed all 13 CI jobs.
- [x] CI-produced AARs and APK attached to the release with a CycloneDX SBOM and verified SHA-256 manifest.
- [x] Clean external Gradle consumer assembled against the attached Maven-style repository contents.
- [x] Failure artifact from the prior Firefox CI run identified a never-settling `navigator.clipboard.writeText()` call.
- [x] Focused Firefox regression passes: 2/2.
- [x] Full `pnpm run check` passes: 392/392 tests plus typecheck, lint, corpus, docs, builds, and action probes.
- [x] Full `pnpm run test:visual` passes: 27/27 across Chromium, Firefox, and WebKit.
- [x] Ran `git diff --check`.
- [x] No Changesets entry is needed because no published package changed.

## Security and language review

No bidi-control behavior or language claim changed. Clipboard operations retain the existing logical-source checks and now fail closed to the existing selection/manual-copy fallbacks after two seconds. Maven Central is explicitly not claimed; signed Central publication still requires maintainer-controlled Sonatype namespace, portal token, and signing material.