### PR TITLE
release(android): publish Maven Central 0.1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+
+  - package-ecosystem: gradle
+    directory: /android
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,0 +1,170 @@
+name: Publish Android libraries to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact Android library version to publish
+        required: true
+        type: string
+      confirmation:
+        description: Type "PUBLISH ANDROID <version>"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-maven-central-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: maven-release
+    timeout-minutes: 90
+    env:
+      ANDROID_RELEASE_VERSION: '0.1.1'
+      SIGNING_KEY_FINGERPRINT: ${{ vars.MAVEN_SIGNING_KEY_FINGERPRINT }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+          cache-dependency-path: |
+            android/**/*.gradle.kts
+            android/gradle/wrapper/gradle-wrapper.properties
+      - name: Validate immutable release request
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+          RELEASE_CONFIRMATION: ${{ inputs.confirmation }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SIGNING_IN_MEMORY_KEY: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+        run: |
+          set -euo pipefail
+          test "$REQUESTED_VERSION" = "$ANDROID_RELEASE_VERSION"
+          test "$RELEASE_CONFIRMATION" = "PUBLISH ANDROID $ANDROID_RELEASE_VERSION"
+          test -n "$MAVEN_CENTRAL_USERNAME"
+          test -n "$MAVEN_CENTRAL_PASSWORD"
+          test -n "$SIGNING_IN_MEMORY_KEY"
+          test -n "$SIGNING_KEY_FINGERPRINT"
+          grep -F 'version = "'"$ANDROID_RELEASE_VERSION"'"' android/build.gradle.kts
+          test "$(git rev-parse --abbrev-ref HEAD)" = "main"
+          status="$(
+            curl --location --silent --show-error --retry 3 \
+              --output /dev/null --write-out '%{http_code}' \
+            "https://repo.maven.apache.org/maven2/io/github/codeinscrubs/bidilens/bidilens-core/$ANDROID_RELEASE_VERSION/bidilens-core-$ANDROID_RELEASE_VERSION.pom" \
+          )"
+          case "$status" in
+            404) ;;
+            200)
+              echo "Version $ANDROID_RELEASE_VERSION is already immutable on Maven Central." >&2
+              exit 1
+              ;;
+            *)
+              echo "Maven Central preflight returned unexpected HTTP $status." >&2
+              exit 1
+              ;;
+          esac
+      - name: Verify libraries, sample, and isolated consumer
+        env:
+          MAVEN_REPO: ${{ runner.temp }}/bidilens-m2/repository
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+        run: |
+          set -euo pipefail
+          chmod +x android/gradlew
+          ./android/gradlew -p android \
+            :core:testDebugUnitTest \
+            :views:testDebugUnitTest \
+            :compose:testDebugUnitTest \
+            :core:lintRelease \
+            :views:lintRelease \
+            :compose:lintRelease \
+            :sample:lintDebug \
+            :core:assembleRelease \
+            :views:assembleRelease \
+            :compose:assembleRelease \
+            :sample:assembleDebug \
+            publishToMavenLocal \
+            -Dmaven.repo.local="$MAVEN_REPO" \
+            --no-configuration-cache \
+            --stacktrace --console=plain
+          ./android/gradlew -p android/consumer-smoke \
+            clean assembleDebug \
+            -Dmaven.repo.local="$MAVEN_REPO" \
+            --no-configuration-cache \
+            --stacktrace --console=plain
+      - name: Verify signed Central inputs and retain checksums
+        env:
+          MAVEN_REPO: ${{ runner.temp }}/bidilens-m2/repository
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+        run: |
+          set -euo pipefail
+          release_root="$MAVEN_REPO/io/github/codeinscrubs/bidilens"
+          verify_home="$(mktemp -d)"
+          chmod 700 "$verify_home"
+          printf '%s' "$ORG_GRADLE_PROJECT_signingInMemoryKey" |
+            gpg --batch --homedir "$verify_home" --import
+          imported_fingerprint="$(
+            gpg --batch --homedir "$verify_home" --with-colons --list-keys |
+              awk -F: '$1 == "fpr" { print $10; exit }'
+          )"
+          test "$imported_fingerprint" = "$SIGNING_KEY_FINGERPRINT"
+
+          for artifact in bidilens-core bidilens-android-views bidilens-android-compose; do
+            artifact_dir="$release_root/$artifact/$ANDROID_RELEASE_VERSION"
+            test -f "$artifact_dir/$artifact-$ANDROID_RELEASE_VERSION.aar"
+            test -f "$artifact_dir/$artifact-$ANDROID_RELEASE_VERSION-sources.jar"
+            test -f "$artifact_dir/$artifact-$ANDROID_RELEASE_VERSION-javadoc.jar"
+            test -f "$artifact_dir/$artifact-$ANDROID_RELEASE_VERSION.pom"
+            grep -F '<url>https://github.com/CodeinScrubs/BidiLens</url>' \
+              "$artifact_dir/$artifact-$ANDROID_RELEASE_VERSION.pom"
+            grep -F '<name>MIT License</name>' \
+              "$artifact_dir/$artifact-$ANDROID_RELEASE_VERSION.pom"
+            for signature in "$artifact_dir"/*.asc; do
+              signed_file="${signature%.asc}"
+              test -f "$signed_file"
+              gpg --batch --homedir "$verify_home" --verify "$signature" "$signed_file"
+            done
+          done
+
+          test "$(
+            find "$release_root" -type f -name '*.asc' | wc -l
+          )" -ge 15
+          (
+            cd "$MAVEN_REPO"
+            find io/github/codeinscrubs/bidilens -type f -print0 |
+              sort -z |
+              xargs -0 sha256sum > "$RUNNER_TEMP/bidilens-android-$ANDROID_RELEASE_VERSION-sha256.txt"
+          )
+      - name: Publish signed deployment and wait for Maven Central
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+        run: |
+          set -euo pipefail
+          ./android/gradlew -p android \
+            publishAndReleaseToMavenCentral \
+            --no-configuration-cache \
+            --stacktrace --console=plain
+      - name: Retain exact signed release inputs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bidilens-android-maven-${{ inputs.version }}
+          path: |
+            ${{ runner.temp }}/bidilens-m2/repository/io/github/codeinscrubs/bidilens/
+            ${{ runner.temp }}/bidilens-android-${{ inputs.version }}-sha256.txt
+            android/*/build/outputs/aar/*.aar
+            android/sample/build/outputs/apk/debug/*.apk
+            android/*/build/reports/lint-results-*.html
+          if-no-files-found: error
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ is published under the public `@bidilens` npm scope.
   coordinates and their published dependency graph.
 - Kept editable values free of bidi controls, preserved Compose accessibility
   semantics, restored View state, and retained an exact pure-LTR no-op path.
+- Prepared Android `0.1.1` as the first signed Maven Central release, with
+  Central-complete POM metadata, source and documentation jars, detached
+  signatures, isolated-consumer verification, and a protected manual release
+  workflow that rejects version reuse.
 
 ### Direction correctness
 

--- a/android/README.md
+++ b/android/README.md
@@ -32,7 +32,24 @@ Android Gradle Plugin 9.2.1, compile SDK 36, and Kotlin 2.3.10.
 
 ## Use with Jetpack Compose
 
-For the current public release, download and extract
+The `0.1.1` source is prepared for the first signed Maven Central publication.
+After the coordinate below resolves from Central, normal Gradle setup is:
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+dependencies {
+    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.1")
+}
+```
+
+Until Central confirms that release, download and extract the immutable
+pre-Central
 [`bidilens-android-v0.1.0-maven-repository.zip`](https://github.com/CodeinScrubs/BidiLens/releases/download/android-v0.1.0/bidilens-android-v0.1.0-maven-repository.zip)
 inside your project, then point Gradle at the extracted repository:
 
@@ -46,7 +63,15 @@ dependencyResolutionManagement {
 }
 ```
 
-Alternatively, build the modules from this checkout once:
+Use `0.1.0` with that archived repository:
+
+```kotlin
+dependencies {
+    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.0")
+}
+```
+
+Alternatively, build the current `0.1.1` modules from this checkout once:
 
 ```bash
 ./android/gradlew -p android publishToMavenLocal
@@ -56,7 +81,7 @@ Then add:
 
 ```kotlin
 dependencies {
-    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.0")
+    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.1")
 }
 ```
 
@@ -156,13 +181,15 @@ Current executable evidence includes:
 
 ## Distribution status
 
-The native modules are source-complete and available in the
+The native modules are source-complete. Version `0.1.1` has signed
+Central-complete publication metadata and a protected release workflow, but it
+is not claimed as publicly available from Maven Central until the deployment
+and a public-only consumer are verified. The
 [`android-v0.1.0` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.0)
-as an external-consumer-tested Maven repository bundle, individual AARs, a
-sample APK, an SBOM, and SHA-256 checksums. Their coordinates are not claimed
-as Maven Central artifacts until the first signed Central release exists.
-Source checkout and `publishToMavenLocal` remain supported. The npm packages
-remain a separate JavaScript/web distribution.
+remains available as an external-consumer-tested Maven repository bundle,
+individual AARs, a sample APK, an SBOM, and SHA-256 checksums. Source checkout
+and `publishToMavenLocal` remain supported. The npm packages remain a separate
+JavaScript/web distribution.
 
 See the repository [limitations](../docs/LIMITATIONS.md), [architecture](../docs/ARCHITECTURE.md),
 and [security policy](../SECURITY.md) before production rollout.

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,10 +2,10 @@ plugins {
     id("com.android.application") version "9.2.1" apply false
     id("com.android.library") version "9.2.1" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.3.10" apply false
-    id("maven-publish")
+    id("com.vanniktech.maven.publish") version "0.37.0" apply false
 }
 
 allprojects {
     group = "io.github.codeinscrubs.bidilens"
-    version = "0.1.0"
+    version = "0.1.1"
 }

--- a/android/compose/build.gradle.kts
+++ b/android/compose/build.gradle.kts
@@ -1,7 +1,11 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.plugin.compose")
-    id("maven-publish")
+    id("com.vanniktech.maven.publish")
 }
 
 android {
@@ -23,12 +27,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-        }
-    }
 }
 
 dependencies {
@@ -43,38 +41,50 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.11.4")
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                artifactId = "bidilens-android-compose"
-                from(components["release"])
-                pom {
-                    name = "BidiLens Android Compose"
-                    description = "Jetpack Compose text and text-field integration for mixed-direction content."
-                    url = "https://github.com/CodeinScrubs/BidiLens"
-                    inceptionYear = "2026"
-                    licenses {
-                        license {
-                            name = "MIT License"
-                            url = "https://opensource.org/license/mit"
-                            distribution = "repo"
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = "CodeinScrubs"
-                            name = "CodeinScrubs"
-                            url = "https://github.com/CodeinScrubs"
-                        }
-                    }
-                    scm {
-                        url = "https://github.com/CodeinScrubs/BidiLens"
-                        connection = "scm:git:https://github.com/CodeinScrubs/BidiLens.git"
-                        developerConnection = "scm:git:ssh://git@github.com/CodeinScrubs/BidiLens.git"
-                    }
-                }
+mavenPublishing {
+    configure(
+        AndroidSingleVariantLibrary(
+            javadocJar = JavadocJar.Empty(),
+            sourcesJar = SourcesJar.Sources(),
+            variant = "release",
+        ),
+    )
+    publishToMavenCentral()
+    if (providers.gradleProperty("signingInMemoryKey").isPresent) {
+        signAllPublications()
+    }
+    coordinates(project.group.toString(), "bidilens-android-compose", project.version.toString())
+    pom {
+        name = "BidiLens Android Compose"
+        description = "Jetpack Compose text and text-field integration for mixed-direction content."
+        url = "https://github.com/CodeinScrubs/BidiLens"
+        inceptionYear = "2026"
+        licenses {
+            license {
+                name = "MIT License"
+                url = "https://opensource.org/license/mit"
+                distribution = "repo"
             }
+        }
+        developers {
+            developer {
+                id = "CodeinScrubs"
+                name = "CodeinScrubs"
+                url = "https://github.com/CodeinScrubs"
+            }
+        }
+        scm {
+            url = "https://github.com/CodeinScrubs/BidiLens"
+            connection = "scm:git:https://github.com/CodeinScrubs/BidiLens.git"
+            developerConnection = "scm:git:ssh://git@github.com/CodeinScrubs/BidiLens.git"
+        }
+        issueManagement {
+            system = "GitHub"
+            url = "https://github.com/CodeinScrubs/BidiLens/issues"
+        }
+        ciManagement {
+            system = "GitHub Actions"
+            url = "https://github.com/CodeinScrubs/BidiLens/actions"
         }
     }
 }

--- a/android/consumer-smoke/build.gradle.kts
+++ b/android/consumer-smoke/build.gradle.kts
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    implementation("io.github.codeinscrubs.bidilens:bidilens-core:0.1.0")
-    implementation("io.github.codeinscrubs.bidilens:bidilens-android-views:0.1.0")
-    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.0")
+    implementation("io.github.codeinscrubs.bidilens:bidilens-core:0.1.1")
+    implementation("io.github.codeinscrubs.bidilens:bidilens-android-views:0.1.1")
+    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.1")
 }

--- a/android/core/build.gradle.kts
+++ b/android/core/build.gradle.kts
@@ -1,6 +1,10 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
+
 plugins {
     id("com.android.library")
-    id("maven-publish")
+    id("com.vanniktech.maven.publish")
 }
 
 android {
@@ -28,50 +32,56 @@ android {
             it.useJUnit()
         }
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-        }
-    }
 }
 
 dependencies {
     testImplementation("junit:junit:4.13.2")
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                artifactId = "bidilens-core"
-                from(components["release"])
-                pom {
-                    name = "BidiLens Android Core"
-                    description = "Dependency-light mixed-direction text analysis for Android."
-                    url = "https://github.com/CodeinScrubs/BidiLens"
-                    inceptionYear = "2026"
-                    licenses {
-                        license {
-                            name = "MIT License"
-                            url = "https://opensource.org/license/mit"
-                            distribution = "repo"
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = "CodeinScrubs"
-                            name = "CodeinScrubs"
-                            url = "https://github.com/CodeinScrubs"
-                        }
-                    }
-                    scm {
-                        url = "https://github.com/CodeinScrubs/BidiLens"
-                        connection = "scm:git:https://github.com/CodeinScrubs/BidiLens.git"
-                        developerConnection = "scm:git:ssh://git@github.com/CodeinScrubs/BidiLens.git"
-                    }
-                }
+mavenPublishing {
+    configure(
+        AndroidSingleVariantLibrary(
+            javadocJar = JavadocJar.Empty(),
+            sourcesJar = SourcesJar.Sources(),
+            variant = "release",
+        ),
+    )
+    publishToMavenCentral()
+    if (providers.gradleProperty("signingInMemoryKey").isPresent) {
+        signAllPublications()
+    }
+    coordinates(project.group.toString(), "bidilens-core", project.version.toString())
+    pom {
+        name = "BidiLens Android Core"
+        description = "Dependency-light mixed-direction text analysis for Android."
+        url = "https://github.com/CodeinScrubs/BidiLens"
+        inceptionYear = "2026"
+        licenses {
+            license {
+                name = "MIT License"
+                url = "https://opensource.org/license/mit"
+                distribution = "repo"
             }
+        }
+        developers {
+            developer {
+                id = "CodeinScrubs"
+                name = "CodeinScrubs"
+                url = "https://github.com/CodeinScrubs"
+            }
+        }
+        scm {
+            url = "https://github.com/CodeinScrubs/BidiLens"
+            connection = "scm:git:https://github.com/CodeinScrubs/BidiLens.git"
+            developerConnection = "scm:git:ssh://git@github.com/CodeinScrubs/BidiLens.git"
+        }
+        issueManagement {
+            system = "GitHub"
+            url = "https://github.com/CodeinScrubs/BidiLens/issues"
+        }
+        ciManagement {
+            system = "GitHub Actions"
+            url = "https://github.com/CodeinScrubs/BidiLens/actions"
         }
     }
 }

--- a/android/sample/build.gradle.kts
+++ b/android/sample/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = 23
         targetSdk = 36
         versionCode = 1
-        versionName = "0.1.0"
+        versionName = "0.1.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android/views/build.gradle.kts
+++ b/android/views/build.gradle.kts
@@ -1,6 +1,10 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
+
 plugins {
     id("com.android.library")
-    id("maven-publish")
+    id("com.vanniktech.maven.publish")
 }
 
 android {
@@ -25,12 +29,6 @@ android {
     testOptions {
         unitTests.isIncludeAndroidResources = true
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-        }
-    }
 }
 
 dependencies {
@@ -43,38 +41,50 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                artifactId = "bidilens-android-views"
-                from(components["release"])
-                pom {
-                    name = "BidiLens Android Views"
-                    description = "Non-destructive TextView and EditText integration for mixed-direction text."
-                    url = "https://github.com/CodeinScrubs/BidiLens"
-                    inceptionYear = "2026"
-                    licenses {
-                        license {
-                            name = "MIT License"
-                            url = "https://opensource.org/license/mit"
-                            distribution = "repo"
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = "CodeinScrubs"
-                            name = "CodeinScrubs"
-                            url = "https://github.com/CodeinScrubs"
-                        }
-                    }
-                    scm {
-                        url = "https://github.com/CodeinScrubs/BidiLens"
-                        connection = "scm:git:https://github.com/CodeinScrubs/BidiLens.git"
-                        developerConnection = "scm:git:ssh://git@github.com/CodeinScrubs/BidiLens.git"
-                    }
-                }
+mavenPublishing {
+    configure(
+        AndroidSingleVariantLibrary(
+            javadocJar = JavadocJar.Empty(),
+            sourcesJar = SourcesJar.Sources(),
+            variant = "release",
+        ),
+    )
+    publishToMavenCentral()
+    if (providers.gradleProperty("signingInMemoryKey").isPresent) {
+        signAllPublications()
+    }
+    coordinates(project.group.toString(), "bidilens-android-views", project.version.toString())
+    pom {
+        name = "BidiLens Android Views"
+        description = "Non-destructive TextView and EditText integration for mixed-direction text."
+        url = "https://github.com/CodeinScrubs/BidiLens"
+        inceptionYear = "2026"
+        licenses {
+            license {
+                name = "MIT License"
+                url = "https://opensource.org/license/mit"
+                distribution = "repo"
             }
+        }
+        developers {
+            developer {
+                id = "CodeinScrubs"
+                name = "CodeinScrubs"
+                url = "https://github.com/CodeinScrubs"
+            }
+        }
+        scm {
+            url = "https://github.com/CodeinScrubs/BidiLens"
+            connection = "scm:git:https://github.com/CodeinScrubs/BidiLens.git"
+            developerConnection = "scm:git:ssh://git@github.com/CodeinScrubs/BidiLens.git"
+        }
+        issueManagement {
+            system = "GitHub"
+            url = "https://github.com/CodeinScrubs/BidiLens/issues"
+        }
+        ciManagement {
+            system = "GitHub Actions"
+            url = "https://github.com/CodeinScrubs/BidiLens/actions"
         }
     }
 }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -7,27 +7,49 @@ required for future releases.
 
 ## Android distribution boundary
 
-The Android modules under `android/` are configured as Maven publications and
-can be verified with `./android/gradlew -p android publishToMavenLocal`.
-Release AARs and sources jars are built by CI. The verified
+The three Android `0.1.1` libraries under `android/` are configured as signed
+Maven Central publications and can be verified locally with
+`./android/gradlew -p android publishToMavenLocal`. The verified
 [`android-v0.1.0` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.0)
-contains the CI AARs, an external-consumer-tested Maven repository bundle, a
-sample APK, an SBOM, and SHA-256 checksums tied to commit `85b80c0`. These
-artifacts must not be described as Maven Central artifacts until all of the
-following are complete:
-
-- Central namespace ownership for `io.github.codeinscrubs.bidilens`;
-- GPG/signing material managed outside the repository;
-- signed POM, sources, and documentation artifacts accepted by Central;
-- a clean external Gradle consumer that resolves all three coordinates from
-  the public repository;
-- checksum retention and a GitHub release tied to the exact source commit.
+remains the immutable pre-Central fallback tied to commit `85b80c0`.
 
 GitHub Packages is not the default public distribution route because even
-public packages impose authentication friction on Gradle consumers. Until a
-signed Central release exists, the [Android guide](../android/README.md)
-documents source checkout, Maven Local, and release-AAR use without implying
-registry publication.
+public packages impose authentication friction on Gradle consumers.
+
+The `io.github.codeinscrubs` Central namespace is verified. Signing material is
+kept outside the repository in the protected `maven-release` GitHub
+environment, and its public fingerprint is
+[`B635C6985216FC5DEB5DDCDD68BE2D5CE18F72C6`](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB635C6985216FC5DEB5DDCDD68BE2D5CE18F72C6).
+The release gate creates and checks the AAR, POM, Gradle metadata, sources jar,
+documentation jar, and detached signature for all three coordinates; compiles
+a clean consumer against an isolated Maven repository; retains SHA-256
+evidence; and only then uploads. The libraries must not be described as
+publicly available from Maven Central until Central accepts the deployment and
+a clean consumer resolves it from the public repository.
+
+### Android release workflow
+
+The manual `publish-android.yml` workflow is restricted to `main` and the
+protected `maven-release` environment. It requires the exact version and exact
+`PUBLISH ANDROID <version>` confirmation, rejects a version already visible on
+Central, and has read-only repository permissions. Registry credentials and
+the private signing key are exposed only to the specific steps that require
+them.
+
+For Android `0.1.1`:
+
+1. merge only after all protected CI checks pass;
+2. dispatch `publish-android.yml` with version `0.1.1` and confirmation
+   `PUBLISH ANDROID 0.1.1`;
+3. approve the protected `maven-release` deployment;
+4. wait for Central validation and public synchronization;
+5. resolve all three exact coordinates from a clean public-only consumer;
+6. create `android-v0.1.1` on the exact published commit and retain the signed
+   Maven inputs, sample APK, checksum manifest, and release notes.
+
+Maven Central versions are immutable. A failed or partially visible release is
+never repaired by replacing `0.1.1`; the next corrected source must use a new
+version.
 
 ## Completed repository prerequisites
 


### PR DESCRIPTION
## What changed

Prepared the native Android libraries for their first immutable Maven Central release as `0.1.1`.

- replaced the ad-hoc Maven publications with the Central-aware Vanniktech plugin;
- publishes release AARs, sources jars, documentation jars, complete POMs, Gradle metadata, checksums, and detached signatures for core, Views, and Compose;
- added a protected, manual, exact-version GitHub workflow that tests and signs before upload;
- validates all signatures and compiles an isolated Maven consumer before registry mutation;
- added Gradle dependency monitoring and updated the Android/publishing documentation;
- preserves the existing library behavior and ordinary-LTR no-op contract.

## Evidence

- [x] Added or updated a focused regression test. (No direction behavior changed; existing Android suites passed.)
- [x] Added or updated a corpus fixture when direction policy changed. (Not applicable: no policy change.)
- [x] Confirmed source text, selection, and copy order remain logical.
- [x] Ran `pnpm run check` (16 files, 392 tests; corpus 918/918; docs/build/action gates pass).
- [x] Ran `pnpm run android:check` (unit tests, lint, AAR/APK builds, Maven local publication, isolated consumer pass).
- [x] Generated all three signed `0.1.1` publications locally and independently verified all 15 detached signatures.
- [x] Parsed Central POM metadata and dependency versions, validated sources/javadoc jars, and compiled the isolated consumer from the signed repository.
- [x] Ran actionlint 1.7.12 and `git diff --check`.
- [x] Added a Changesets entry for a published-package API or behavior change. (Not applicable: Android uses a separate version and no npm API changed.)

## Security and language review

No text-analysis behavior, bidi-control handling, or language claim changed. Maven Central credentials and the private signing key are not in the repository: they are restricted to the protected `maven-release` environment and only exposed to workflow steps that require them. The public signing fingerprint is documented and independently retrievable from the Ubuntu keyserver. Central publication remains impossible until this PR passes protected CI, merges to `main`, and the protected release environment is approved.