### PR TITLE
docs: record npm 0.3.0 publication

### DIFF
--- a/docs/OUTREACH.md
+++ b/docs/OUTREACH.md
@@ -1,6 +1,6 @@
 # Maintainer outreach kit
 
-BidiLens web `0.2.0` and signed Android `0.1.1` are published for source review
+BidiLens web `0.3.0` and signed Android `0.1.1` are published for source review
 and bounded pilots. Android has emulator and public-consumer evidence;
 physical-device/OEM/IME/TalkBack and production validation remain pending.
 Neither availability is evidence of adoption. Contact maintainers with one
@@ -21,17 +21,19 @@ small renderer pilot
 Hello [team or maintainer],
 
 I maintain [BidiLens](https://github.com/CodeinScrubs/BidiLens), an MIT-licensed
-TypeScript and native Android toolkit for mixed RTL/LTR AI messages. It fixes a common failure in
-which a technically named sentence such as `React یک کتابخانه … است.` receives
-the wrong paragraph direction, while leaving ordinary LTR content free of
-BidiLens attributes, wrappers, styles, or source changes.
+TypeScript and Android toolkit with Swift/UIKit and .NET/WPF source adapters
+for mixed RTL/LTR AI messages. It fixes a common failure in which a technically
+named sentence such as `React یک کتابخانه … است.` receives the wrong paragraph
+direction, while leaving ordinary LTR content free of BidiLens attributes,
+wrappers, styles, or source changes.
 
 The repository includes Unicode 17-derived classification, per-block direction,
 semantic isolation, streaming reconciliation, bidi-control auditing, adapters
-for major web renderers, native Kotlin/Views/Compose modules, 918 direction
-fixtures, three-browser tests, and Android emulator tests. Twelve public npm
-packages include provenance; three signed Maven Central modules and missing
-external validation are documented explicitly.
+for major web renderers, native Kotlin/Views/Compose modules, compiler-tested
+Swift/UIKit and .NET/WPF adapters, 918 direction fixtures, three-browser tests,
+and Android emulator tests. Twelve public npm packages include provenance;
+three signed Maven Central modules, source-only Apple/Windows distribution, and
+missing external validation are documented explicitly.
 
 Would you be open to reviewing a small, reversible pilot in [specific renderer
 or component]? I can provide a focused integration patch and host-specific
@@ -44,9 +46,11 @@ Thank you,
 
 - Problem and quick start: [README](../README.md)
 - Published packages: [`@bidilens` on npm](https://www.npmjs.com/org/bidilens)
-- Versioned web release: [`v0.2.0` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.2.0)
+- Versioned web release: [`v0.3.0` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.0)
 - Versioned Android release: [`android-v0.1.1` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1)
 - Native Android integration: [Android guide](../android/README.md)
+- Apple integration: [Swift/UIKit guide](../apple/README.md)
+- Windows integration: [.NET/WPF guide](../windows/README.md)
 - Exact boundaries: [Limitations](LIMITATIONS.md)
 - Pilot and rollback criteria: [Adoption strategy](ADOPTION.md)
 - Architecture and threat model: [Architecture](ARCHITECTURE.md) and
@@ -64,11 +68,12 @@ pnpm run test:visual
 pnpm run release:check
 ```
 
-For an initial web review, install `@bidilens/core@0.2.0`; for Android, use one
+For an initial web review, install `@bidilens/core@0.3.0`; for Android, use one
 exact `io.github.codeinscrubs.bidilens:*:0.1.1` coordinate. Ask for confirmation
 of the host bug, feedback on the API boundary, or permission to prepare a small
 draft pull request. Do not claim universal rendering, zero defects,
-native-platform coverage beyond Android, adoption, or company endorsement.
+native-platform coverage beyond the documented Android, UIKit, and WPF
+surfaces, physical Apple/Windows validation, adoption, or company endorsement.
 Registry availability is verifiable, but adoption is not. Browser/OS layout
 engines still perform
 Unicode reordering and shaping; BidiLens supplies the application structure and

--- a/docs/PROJECT_COMPARISON.md
+++ b/docs/PROJECT_COMPARISON.md
@@ -186,7 +186,7 @@ lockfile install:
   pin in the security self-scan job prevents that job from reaching its scan;
 - the declared GitHub repository does not exist and npm returns `E404` for
   both `@bidiguard/core` and `@bidiguard/react-native`. Canonical BidiLens is
-  public and its 12 packages resolve at version `0.2.0`.
+  public and its 12 packages resolve at version `0.3.0`.
 
 Passing tests also miss release- and behavior-critical defects reproduced
 against the built sibling artifacts:

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -2,7 +2,7 @@
 
 The canonical source is published at
 [`CodeinScrubs/BidiLens`](https://github.com/CodeinScrubs/BidiLens). This
-checklist records the completed web/npm `0.2.0` and Android/Maven `0.1.1`
+checklist records the completed web/npm `0.3.0` and Android/Maven `0.1.1`
 releases and the controls required for future releases.
 
 ## Android distribution boundary
@@ -66,22 +66,23 @@ version.
 - verified `shayanay80` owner access to the `bidilens` npm organization and
   `@bidilens` scope;
 - identified bootstrap maintainer and CODEOWNERS;
-- strict `main` protection requires all 13 CI job contexts, including the
-  Android library/sample build and API 35 UI-test gate, on an up-to-date
-  branch and linear history, while blocking force-pushes, branch deletion, and
-  unresolved review conversations; the sole-maintainer administrative bypass
-  remains available for CI-outage recovery;
+- strict `main` protection requires all 15 CI job contexts, including the
+  Android library/sample build and API 35 UI-test gate plus Apple and Windows
+  compiler gates, on an up-to-date branch and linear history, while blocking
+  force-pushes, branch deletion, and unresolved review conversations; the
+  sole-maintainer administrative bypass remains available for CI-outage
+  recovery;
 - GitHub Private Vulnerability Reporting and least-privilege workflow defaults;
 - MIT project license plus Unicode and imported-corpus notices;
 - human-controlled release preparation and protected npm publication
   workflows;
-- all 12 `@bidilens/*@0.2.0` packages published publicly with SLSA provenance;
+- all 12 `@bidilens/*@0.3.0` packages published publicly with SLSA provenance;
 - retained release tarballs whose SHA-512 values match the public registry;
 - per-package GitHub OIDC trusted publishers bound to `publish.yml` and the
   protected `npm-release` environment;
 - token-based publishing disabled through npm's recommended
   `Require two-factor authentication and disallow tokens` package setting;
-- annotated `v0.2.0` tag and immutable GitHub release for the exact published
+- annotated `v0.3.0` tag and immutable GitHub release for the exact published
   source commit, with all package tarballs, release manifest, and SBOM attached.
 - signed Android `0.1.1` artifacts published under the verified
   `io.github.codeinscrubs.bidilens` namespace, with protected release evidence,
@@ -95,20 +96,20 @@ version.
   deployment risk;
 - decide whether the ESM-only boundary is acceptable for target adopters.
 
-On 2026-07-27, the exact published source commit passed
-[all 11 CI jobs](https://github.com/CodeinScrubs/BidiLens/actions/runs/30297267976),
+On 2026-07-28, the exact published source commit passed
+[all 15 CI jobs](https://github.com/CodeinScrubs/BidiLens/actions/runs/30352957959),
 and protected publication run
-[`30297697861`](https://github.com/CodeinScrubs/BidiLens/actions/runs/30297697861)
-published all 12 version `0.2.0` packages. Independent verification matched the
-retained tarball SHA-256 values, release-manifest registry SHA-512 values, npm
-integrity metadata, `latest` tags, and SLSA provenance for every package. A
-clean external consumer then installed the complete exact-version set from
-npm, imported all 12 packages, exercised mixed Persian/English and pure-LTR
-runtime behavior plus the CLI, and reported zero production audit findings
-with current peers. The annotated
-[`v0.2.0`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.2.0) tag
+[`30352982906`](https://github.com/CodeinScrubs/BidiLens/actions/runs/30352982906)
+published all 12 version `0.3.0` packages. Before publication, the exact-commit
+packed-consumer gates built, packed, installed, imported, and exercised all 12
+release artifacts in clean consumers. After publication, independent
+verification matched the retained tarball SHA-256 values, release-manifest
+registry SHA-512 values, npm integrity metadata, `latest` tags, and SLSA
+provenance for every package. The annotated
+[`v0.3.0`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.0) tag
 resolves to that commit, and the immutable release retains the 12 exact
-tarballs, release manifest, and validated CycloneDX SBOM.
+tarballs, release manifest, validated CycloneDX SBOM, and SHA-256 checksum
+manifest.
 
 An earlier protected attempt,
 [`30296472757`](https://github.com/CodeinScrubs/BidiLens/actions/runs/30296472757),

--- a/docs/REQUIREMENT_MATRIX.md
+++ b/docs/REQUIREMENT_MATRIX.md
@@ -135,7 +135,7 @@ recorded explicitly.
 | CI: VS Code and native builds | Partial | Android unit/lint/AAR/APK and API 35 device jobs are pinned and executable; signed Android publication has an isolated-consumer gate; Apple Swift/iOS and Windows .NET/WPF compiler jobs have passing hosted evidence. VS Code and unimplemented native-platform adapters remain open |
 | Changesets and human-controlled release workflow | Complete | Changesets configuration, opt-in web release preparation, protected manual npm publication with exact confirmation and provenance, and protected manual Maven Central publication with signing and version-reuse rejection |
 | Clean packed consumer | Complete and tested | `pnpm run release:check` passes from the reviewed clean commit: all 12 packages build, pack, inspect, install into a strict consumer, import at runtime, and execute their exact packed examples |
-| Registry ownership, provenance, public repo metadata, credentials | Complete for the published package set | Canonical GitHub metadata, `@bidilens` ownership, and `io.github.codeinscrubs` namespace verified; all 12 npm `0.2.0` packages are public with SLSA provenance and matching integrity; all three Android `0.1.1` modules are signed and public with matching Central artifacts, signatures, and checksums; release credentials are protected outside the repository |
+| Registry ownership, provenance, public repo metadata, credentials | Complete for the published package set | Canonical GitHub metadata, `@bidilens` ownership, and `io.github.codeinscrubs` namespace verified; all 12 npm `0.3.0` packages are public with SLSA provenance and matching integrity; all three Android `0.1.1` modules are signed and public with matching Central artifacts, signatures, and checksums; release credentials are protected outside the repository |
 | Name/trademark decision | Partial/external | ADR records provisional `BidiLens`; final registry/legal review is still required |
 
 ## Milestone gate status
@@ -152,9 +152,9 @@ tag. Therefore working code alone cannot make an historical milestone green.
 | M4 frameworks/Electron | Partial | Web Component/React/Vue/Svelte pass anti-hollow and SSR gates; Electron is missing; no `m4` tag |
 | M5 CLI/Playwright Action/VS Code | Partial | CLI, reusable Playwright helpers, and bundled conformance Action pass; VS Code extension is missing; no `m5` tag |
 | M6 ≥300/visual/copy | Implemented; historical gate incomplete | 918 corpus cases and 24 three-engine visual tests pass; no `m6` tag |
-| M7 native + terminal | Partial | Terminal and Android exist; Flutter/RN/Swift do not; no `m7` tag |
+| M7 native + terminal | Partial | Terminal, Android, Swift/UIKit, and .NET/WPF exist; Flutter, React Native, and other documented native adapters remain open; no `m7` tag |
 | M8 playground/full EN/FA docs | Implemented; historical gate incomplete | Offline bilingual playground and EN/FA repository docs pass build/browser/link checks; no annotated `m8` tag |
-| M9 release/integrations | Partial | Package release side is complete: clean committed checkout, public npm artifacts, provenance, trusted publishing, SBOM, retained manifest, immutable `v0.2.0` web release, and signed `android-v0.1.1` Maven release. One of the required three host-tested integrations is submitted but unmerged, so the integration minimum remains incomplete |
+| M9 release/integrations | Partial | Package release side is complete: clean committed checkout, public npm artifacts, provenance, trusted publishing, SBOM, retained manifest, immutable `v0.3.0` web release, and signed `android-v0.1.1` Maven release. One of the required three host-tested integrations is submitted but unmerged, so the integration minimum remains incomplete |
 
 ## Definition-of-done audit
 
@@ -174,7 +174,7 @@ tag. Therefore working code alone cannot make an historical milestone green.
 | 12 | Complete for current packages — workflows validate, SBOM/license/notices exist |
 | 13 | Partial — one host-tested integration patch is submitted; fewer than three exist and none is merged or piloted |
 | 14 | Complete for current documented claims; continue checking after every change |
-| 15 | Partial — the reviewed source, current `v0.2.0` web release, and `android-v0.1.1` Maven release are public, but historical intermediate milestone tags were not fabricated retroactively |
+| 15 | Partial — the reviewed source, current `v0.3.0` web release, and `android-v0.1.1` Maven release are public, but historical intermediate milestone tags were not fabricated retroactively |
 
 ## Prior-attempt idea coverage
 


### PR DESCRIPTION
## What changed

Updated current-status documentation to the verified npm 0.3.0 release, its exact CI and protected publication evidence, and the new Swift/UIKit and .NET/WPF source integrations. Historical 0.2.0 changelogs and the historical v1 build report remain unchanged.

Also records the honest distribution boundary: Android 0.1.1 is on Maven Central, while Apple and Windows adapters are compiler-tested source integrations rather than registry-published or physical-device-validated releases.

## Evidence

- [x] Added or updated a focused regression test. Not applicable: documentation-only evidence update.
- [x] Added or updated a corpus fixture when direction policy changed. Not applicable: no policy change.
- [x] Confirmed source text, selection, and copy order remain logical. No runtime source changed; exact v0.3.0 CI passed all 15 jobs.
- [x] Ran `pnpm run check`. Passed on exact v0.3.0 source commit before publication (396 tests); this docs-only branch runs the protected matrix again.
- [x] Ran `pnpm run test:visual` for rendering or adapter changes. Not applicable to this docs-only change; exact v0.3.0 CI passed all three browser jobs.
- [x] Ran package/release gates for manifest, dependency, or public API changes. No manifest/API change; v0.3.0 protected publish and registry integrity/provenance verification succeeded.
- [x] Added a Changesets entry for a published-package API or behavior change. Not applicable: no package change.

Local checks:

- `pnpm run docs:check`
- `git diff --check`
- stale current-version scan excluding historical changelogs/build report
- GitHub branch protection verified strict with all 15 CI contexts

## Security and language review

No runtime handling of untrusted text or bidi controls changed. The Persian example is pre-existing; this PR changes release/version/platform claims only and explicitly preserves the missing native-speaker, physical-device, accessibility, and production-validation limitations.