### PR TITLE
ci: update Gradle wrapper validation to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: '1.26.5'
           cache: false
       - run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
-      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+      - uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
   quality:
     name: Quality (Node ${{ matrix.node }})


### PR DESCRIPTION
## What changed

Updated the exact pinned `gradle/actions/wrapper-validation` commit from v4 to the official v6.2.0 release. The v6 action declares the Node 24 runtime, eliminating GitHub's Node 20 action-runtime deprecation warning while preserving Gradle wrapper checksum validation.

Upstream evidence: https://github.com/gradle/actions/releases/tag/v6.2.0

## Evidence

- [x] Added or updated a focused regression test. The workflow-lint job itself is the focused executable gate for this CI-only change.
- [x] Added or updated a corpus fixture when direction policy changed. Not applicable.
- [x] Confirmed source text, selection, and copy order remain logical. No product source changed.
- [x] Ran `pnpm run check`. No product source changed; the protected matrix runs it on Node 22/24 and Windows/macOS.
- [x] Ran `pnpm run test:visual` for rendering or adapter changes. Not applicable; protected visual jobs still run.
- [x] Ran package/release gates for manifest, dependency, or public API changes. Not applicable; protected packed-consumer jobs still run.
- [x] Added a Changesets entry for a published-package API or behavior change. Not applicable.

Local checks:

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`
- verified upstream v6.2.0 exact commit `3f131e8634966bd73d06cc69884922b02e6faf92`
- verified `wrapper-validation/action.yml` at v6.2.0 declares `using: node24`

## Security and language review

This changes a supply-chain validation action, pinned to the exact commit for Gradle's official v6.2.0 release. It does not handle user text or alter language behavior.