### PR TITLE
chore(android): align Android Gradle Plugin at 9.3.1

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -14,8 +14,8 @@ The Android implementation has three small libraries:
 | `:compose` | 23 | `BidiText`, `BidiBasicTextField`, styles, semantics, and offset-safe visual isolation |
 
 The `:sample` application reproduces the photographed form-field, mixed-label,
-and leading-English cases. The project builds with JDK 21, Gradle 9.4.1,
-Android Gradle Plugin 9.2.1, compile SDK 36, and Kotlin 2.3.10.
+and leading-English cases. The project builds with JDK 21, Gradle 9.6.1,
+Android Gradle Plugin 9.3.1, compile SDK 36, and Kotlin 2.3.10.
 
 ## Safety contract
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.application") version "9.2.1" apply false
-    id("com.android.library") version "9.2.1" apply false
+    id("com.android.application") version "9.3.1" apply false
+    id("com.android.library") version "9.3.1" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.3.10" apply false
     id("com.vanniktech.maven.publish") version "0.37.0" apply false
 }

--- a/android/consumer-smoke/build.gradle.kts
+++ b/android/consumer-smoke/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.library") version "9.2.1"
+    id("com.android.library") version "9.3.1"
     id("org.jetbrains.kotlin.plugin.compose") version "2.3.10"
 }
 


### PR DESCRIPTION
## Summary

- update both root Android application/library plugin pins to AGP 9.3.1
- update the standalone Maven consumer smoke project to the same AGP version
- keep all Android builds on the verified Gradle 9.6.1 wrapper and JDK 21 matrix

This combines and supersedes Dependabot PRs #19 and #22 so application, library, and isolated-consumer validation cannot drift between AGP versions.

## Local verification

- core/views/compose unit tests
- release lint for all libraries and debug lint for the sample
- release AARs, sample APK, and Maven-local publication
- isolated consumer clean build against Maven coordinates
- `--warning-mode all` consumer build with the former Gradle 10 project-notation warning eliminated
- `git diff --check`