### PR TITLE
ci: enforce the declared Node runtime floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
       - dependency-name: "typescript"
         update-types:
           - version-update:semver-major
+      # jsdom 30 requires Node 22.22.2 or 24.15.0. Keep the development
+      # harness compatible with the public Node 22.12 runtime floor until a
+      # deliberate BidiLens major/minor compatibility decision raises it.
+      - dependency-name: "jsdom"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        include:
+          - node: 22
+            runtime: 22.12.0
+          - node: 24
+            runtime: 24.15.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -40,7 +44,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.runtime }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -61,7 +65,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -74,7 +78,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22, 24]
+        include:
+          - node: 22
+            runtime: 22.12.0
+          - node: 24
+            runtime: 24.15.0
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -82,7 +90,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.runtime }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -267,7 +275,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 22.12.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
@@ -297,7 +305,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 22.12.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           version: 10.27.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 22.12.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ is published under the public `@bidilens` npm scope.
 
 ## Unreleased
 
+### Release and verification
+
+- Pinned the supported CI runtimes to exact Node 22.12.0 and 24.15.0 releases
+  so the documented minimum is exercised instead of silently floating to the
+  newest release in each major line.
+- Documented a Node-22.12-compatible Corepack bootstrap and deferred jsdom 30,
+  whose upstream runtime floor would otherwise narrow BidiLens contributor
+  compatibility without an explicit support decision.
+
 ### Windows platforms
 
 - Matched .NET technical-token boundaries to the shared ASCII-boundary policy,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,16 @@ structured issue forms. See [SUPPORT.md](SUPPORT.md) for routing guidance.
 ## Development
 
 ```bash
+npm install --global corepack@0.34.1
 corepack enable
 pnpm install --frozen-lockfile
 pnpm run check
 pnpm run test:visual
 ```
+
+Corepack `0.34.1` is pinned because it supports Node 22.12 and contains the
+current package-manager signing keys; the older Corepack bundled with Node
+22.12 cannot authenticate pnpm 10.27.0.
 
 Android changes additionally require JDK 21 and an Android SDK:
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -125,6 +125,7 @@ import '@bidilens/web-component/auto';
 ## توسعه و بررسی
 
 ```bash
+npm install --global corepack@0.34.1
 corepack enable
 pnpm install --frozen-lockfile
 pnpm run check

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ does not alter source.
 ## Reproduce the release evidence
 
 ```bash
+npm install --global corepack@0.34.1
 corepack enable
 pnpm install --frozen-lockfile
 pnpm run verify:production

--- a/docs/OUTREACH.md
+++ b/docs/OUTREACH.md
@@ -61,6 +61,7 @@ Thank you,
 ## Reviewer fast path
 
 ```bash
+npm install --global corepack@0.34.1
 corepack enable
 pnpm install --frozen-lockfile
 pnpm run check

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -66,12 +66,12 @@ version.
 - verified `shayanay80` owner access to the `bidilens` npm organization and
   `@bidilens` scope;
 - identified bootstrap maintainer and CODEOWNERS;
-- strict `main` protection requires all 15 CI job contexts, including the
+- strict `main` protection requires all 18 CI job contexts, including the
   Android library/sample build and API 35 UI-test gate plus Apple and Windows
-  compiler gates, on an up-to-date branch and linear history, while blocking
-  force-pushes, branch deletion, and unresolved review conversations; the
-  sole-maintainer administrative bypass remains available for CI-outage
-  recovery;
+  compiler gates and the three-platform Rust gate, on an up-to-date branch and
+  linear history, while blocking force-pushes and branch deletion; repository
+  administrators are also subject to these checks, so CI-outage recovery
+  requires an explicit, auditable protection-setting change;
 - GitHub Private Vulnerability Reporting and least-privilege workflow defaults;
 - MIT project license plus Unicode and imported-corpus notices;
 - human-controlled release preparation and protected npm publication
@@ -127,6 +127,7 @@ support, and company endorsement remain unclaimed.
 From a clean checkout with Node.js 22.12+ or 24 and pnpm 10.27.0:
 
 ```bash
+npm install --global corepack@0.34.1
 corepack enable
 pnpm install --frozen-lockfile
 pnpm run verify:production


### PR DESCRIPTION
## Summary

- run the existing Node 22 and Node 24 quality/packed-consumer contexts on exact 22.12.0 and 24.15.0 runtimes while preserving their branch-protection names
- pin the remaining CI/demo/benchmark runtime selections instead of floating across major lines
- document the Corepack 0.34.1 bootstrap required to authenticate pnpm 10.27.0 on Node 22.12
- intentionally ignore jsdom major updates while jsdom 30 requires Node 22.22.2/24.15.0 and BidiLens supports Node 22.12
- correct the current branch-protection documentation to 18 contexts, including all three Rust platforms and enforced administrator checks

## Evidence

- complete `pnpm run check` and actionlint pass locally
- exact portable Node 22.12.0 + pnpm 10.27.0 passed all 396 tests, the 930-case corpus, docs, builds, and action checks
- Node 22.12's bundled Corepack reproduced a signing-key failure; Corepack 0.34.1 authenticated the pinned pnpm successfully
- `git diff --check` and documentation validation pass

After merge, repository protection will be updated to require the three already-existing Rust job contexts. Dependabot PR #10 will then be closed with the compatibility rationale.