### PR TITLE
ci(security): scan every supported language with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,102 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-build:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, csharp, rust]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+      - name: Analyze
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          category: /language:${{ matrix.language }}
+
+  kotlin:
+    name: CodeQL (java-kotlin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+          cache-dependency-path: |
+            android/**/*.gradle.kts
+            android/gradle/wrapper/gradle-wrapper.properties
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+          queries: security-extended
+      - run: chmod +x android/gradlew
+      - name: Build Kotlin sources for extraction
+        run: >-
+          ./android/gradlew -p android
+          :core:compileReleaseKotlin
+          :views:compileReleaseKotlin
+          :compose:compileReleaseKotlin
+          :sample:compileDebugKotlin
+          --no-daemon --stacktrace --console=plain
+      - name: Analyze
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          category: /language:java-kotlin
+
+  swift:
+    name: CodeQL (swift)
+    runs-on: macos-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          languages: swift
+          build-mode: manual
+          queries: security-extended
+      - name: Build Swift package and iOS adapters for extraction
+        run: |
+          swift build
+          xcodebuild \
+            -scheme BidiLens \
+            -destination 'generic/platform=iOS Simulator' \
+            -sdk iphonesimulator \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+      - name: Analyze
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          category: /language:swift

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,9 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  packages: read
   security-events: write
 
 concurrency:
@@ -30,6 +28,8 @@ jobs:
         language: [javascript-typescript, csharp, rust]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
@@ -47,6 +47,8 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
@@ -81,6 +83,8 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ is published under the public `@bidilens` npm scope.
 - Documented a Node-22.12-compatible Corepack bootstrap and deferred jsdom 30,
   whose upstream runtime floor would otherwise narrow BidiLens contributor
   compatibility without an explicit support decision.
+- Added pinned, weekly and pull-request CodeQL `security-extended` analysis for
+  JavaScript/TypeScript, Kotlin, C#, Swift, and Rust, including explicit
+  compiler extraction for the native Kotlin and Swift surfaces.
 
 ### Windows platforms
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,16 @@ support SLA.
 Include a minimal reproduction, affected package/version, expected impact,
 whether untrusted content is required, and any suggested remediation.
 
+## Automated security verification
+
+Pull requests, pushes to `main`, and weekly scheduled runs use CodeQL's
+`security-extended` queries for JavaScript/TypeScript, Kotlin, C#, Swift, and
+Rust. Compiled Kotlin and Swift analysis uses explicit production-relevant
+build commands so those sources are extracted rather than silently skipped.
+The regular CI workflow also performs the pinned dependency audit and validates
+the generated CycloneDX SBOM. These automated gates supplement, but do not
+replace, independent security review or private vulnerability reports.
+
 ## Bidi security scope
 
 Hidden directional controls can change visual order without changing logical

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -66,12 +66,14 @@ version.
 - verified `shayanay80` owner access to the `bidilens` npm organization and
   `@bidilens` scope;
 - identified bootstrap maintainer and CODEOWNERS;
-- strict `main` protection requires all 18 CI job contexts, including the
-  Android library/sample build and API 35 UI-test gate plus Apple and Windows
-  compiler gates and the three-platform Rust gate, on an up-to-date branch and
-  linear history, while blocking force-pushes and branch deletion; repository
-  administrators are also subject to these checks, so CI-outage recovery
-  requires an explicit, auditable protection-setting change;
+- strict `main` protection requires all 23 verification contexts: the 18 CI
+  jobs (including the Android library/sample build, API 35 UI-test gate, Apple
+  and Windows compiler gates, and three-platform Rust gate) plus five CodeQL
+  language analyses for JavaScript/TypeScript, Kotlin, C#, Swift, and Rust. The
+  branch must be up to date and use linear history, while force-pushes and
+  branch deletion are blocked; repository administrators are also subject to
+  these checks, so CI-outage recovery requires an explicit, auditable
+  protection-setting change;
 - GitHub Private Vulnerability Reporting and least-privilege workflow defaults;
 - MIT project license plus Unicode and imported-corpus notices;
 - human-controlled release preparation and protected npm publication


### PR DESCRIPTION
## Summary

- add immutable CodeQL v4.37.4 analysis on pull requests, main pushes, weekly schedule, and manual dispatch
- scan JavaScript/TypeScript, C#, and Rust with supported no-build extraction
- scan Kotlin and Swift with manual JDK 21/Gradle and SwiftPM/Xcode compiler extraction so native sources are not skipped
- use the `security-extended` query suite and least-privilege workflow permissions
- document the automated security boundary without claiming it replaces human review

## Local verification

- actionlint v1.7.12
- documentation/link validation
- `git diff --check`

The CodeQL action SHA is the immutable commit behind official tag v4.37.4. The first hosted run established the five check names; all five are now required by strict `main` protection, bringing the enforced total from 18 to 23 contexts.