### PR TITLE
chore(android): align supported Kotlin toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,12 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    ignore:
+      # Kotlin 2.4.10 is fully supported through Gradle 9.5. Keep the Android
+      # wrapper at that compatibility boundary until JetBrains expands it.
+      - dependency-name: "gradle-wrapper"
+        versions:
+          - "[9.6,)"
 
   - package-ecosystem: cargo
     directory: /rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ is published under the public `@bidilens` npm scope.
 - Kept the dense Markdown streaming performance gate deterministic under
   coverage instrumentation while retaining its strict rich-parse-count bound.
 
+### Android platforms
+
+- Kept paragraph direction independent from physical alignment in Android
+  Views, including immediate restoration of the caller's original gravity
+  when content-driven alignment is disabled.
+- Expanded Kotlin parity to the 930-case canonical corpus and added Views and
+  Compose regressions for physical-left RTL rendering and pure-LTR no-op
+  behavior.
+- Aligned the root and standalone-consumer Compose compiler plugins on Kotlin
+  2.4.10 and pinned Gradle 9.5.0, the documented compatibility boundary for
+  that Kotlin release, while retaining Android Gradle Plugin 9.3.1.
+
 ## 0.3.0 - 2026-07-28
 
 ### Direction and alignment

--- a/android/README.md
+++ b/android/README.md
@@ -14,8 +14,8 @@ The Android implementation has three small libraries:
 | `:compose` | 23 | `BidiText`, `BidiBasicTextField`, styles, semantics, and offset-safe visual isolation |
 
 The `:sample` application reproduces the photographed form-field, mixed-label,
-and leading-English cases. The project builds with JDK 21, Gradle 9.6.1,
-Android Gradle Plugin 9.3.1, compile SDK 36, and Kotlin 2.3.10.
+and leading-English cases. The project builds with JDK 21, Gradle 9.5.0,
+Android Gradle Plugin 9.3.1, compile SDK 36, and Kotlin 2.4.10.
 
 ## Safety contract
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application") version "9.3.1" apply false
     id("com.android.library") version "9.3.1" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.10" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
     id("com.vanniktech.maven.publish") version "0.37.0" apply false
 }
 

--- a/android/consumer-smoke/build.gradle.kts
+++ b/android/consumer-smoke/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.library") version "9.3.1"
-    id("org.jetbrains.kotlin.plugin.compose") version "2.3.10"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10"
 }
 
 android {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,10 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
-distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
+retries=0
+retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

- align both the root Android build and the standalone Maven consumer on the Compose compiler plugin 2.4.10
- pin the wrapper to Gradle 9.5.0 with the official distribution SHA-256, matching Kotlin 2.4.10's documented maximum fully supported Gradle version and AGP 9.3's minimum/default Gradle version
- temporarily defer Gradle wrapper 9.6+ in Dependabot until JetBrains expands Kotlin's compatibility range
- document the supported toolchain and previously unreleased Android alignment/corpus work

## Why this replaces #37

Dependabot #37 changed only `android/build.gradle.kts`; it left `android/consumer-smoke/build.gradle.kts` on 2.3.10 and kept the wrapper on Gradle 9.6.1, outside Kotlin 2.4.10's fully supported Gradle range. This PR keeps the actual consumer gate synchronized and chooses the documented compatibility intersection.

## Verification

- full Android unit-test, lint, release AAR, sample APK, and Maven-local publication task set on JDK 21
- standalone consumer `clean assembleDebug` against the generated Maven coordinates
- Gradle 9.5.0 wrapper checksum verification and `--warning-mode all`
- resolved build environment contains Compose compiler and Kotlin Gradle plugin 2.4.10
- documentation/link validation
- actionlint 1.7.12
- `git diff --check`

Official compatibility references:

- https://kotlinlang.org/docs/gradle-configure-project.html
- https://developer.android.com/build/releases/agp-9-3-0-release-notes
- https://developer.android.com/build/kotlin-support