### PR TITLE
docs: record public 0.3.2 release

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -13,12 +13,13 @@
 [مشارکت](CONTRIBUTING.md) · [وضعیت پروژه](docs/V1_BUILD_REPORT.md)
 
 > [!IMPORTANT]
-> نسخهٔ `0.3.1` بخش وب و JavaScript برای هر ۱۲ بستهٔ `@bidilens/*` در npm
+> نسخهٔ `0.3.2` بخش وب و JavaScript برای هر ۱۲ بستهٔ `@bidilens/*` در npm
 > عمومی است و یکپارچگی رجیستری و SLSA provenance آن‌ها تأیید شده است؛ tarballها،
 > manifest و SBOM دقیق آن در
-> [انتشار تغییرناپذیر `v0.3.1`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.1)
-> نگه‌داری می‌شود. نسخهٔ `0.3.2` کاندید فعلی source است و تا تأیید workflow
-> محافظت‌شده در npm منتشر نمی‌شود. نسخهٔ `0.1.1` هستهٔ Kotlin و ماژول‌های Android Views و
+> [انتشار تغییرناپذیر `v0.3.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2)
+> نگه‌داری می‌شود. این نسخه پس از عبور از گیت کامل انتشار، از commit محافظت‌شدهٔ
+> `97f4827a9683c343a92f4ff31f4fa1fc0a718e99` منتشر شده است. نسخهٔ تاریخی `0.3.1`
+> نیز به‌صورت انتشار تغییرناپذیر در دسترس است. نسخهٔ `0.1.1` هستهٔ Kotlin و ماژول‌های Android Views و
 > Jetpack Compose نیز امضاشده و در Maven Central عمومی است؛ برنامهٔ نمونه و
 > شواهد انتشار در
 > [`android-v0.1.1`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1)
@@ -88,9 +89,9 @@ The Persian word کتاب means “book”.
 Compose و Views در [راهنمای Android](android/README.md) قرار دارد.
 
 تمام بسته‌های عمومی ESM-only هستند و برای استفادهٔ سمت سرور به Node.js 22.12 یا
-جدیدتر نیاز دارند. مجموعهٔ کامل `0.3.1` در
+جدیدتر نیاز دارند. مجموعهٔ کامل `0.3.2` در
 [سازمان `@bidilens` در npm](https://www.npmjs.com/org/bidilens) منتشر شده است؛
-کاندید هم‌نسخهٔ `0.3.2` هنوز یک انتشار عمومی رجیستری نیست.
+مجموعهٔ `0.3.1` نیز به‌عنوان نسخهٔ تاریخی تغییرناپذیر باقی مانده است.
 
 پروژه با [مجوز MIT](LICENSE) متن‌باز است. شرایط داده‌های Unicode و بخش
 Apache-2.0 پیکره در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) حفظ شده
@@ -104,7 +105,7 @@ Apache-2.0 پیکره در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) حف
 استفاده است:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.1"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.2"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@
 [Project status](docs/V1_BUILD_REPORT.md)
 
 > [!IMPORTANT]
-> The JavaScript/web `0.3.1` release is public across all 12 `@bidilens/*`
+> The JavaScript/web `0.3.2` release is public across all 12 `@bidilens/*`
 > packages with verified registry integrity and SLSA provenance; its exact
 > tarballs, manifest, and SBOM are retained in the immutable
-> [`v0.3.1` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.1).
-> Version `0.3.2` is the current source candidate and remains unpublished until
-> the protected release workflow verifies it. Native Android core, Views, and
+> [`v0.3.2` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2).
+> It was published from protected `main` commit
+> `97f4827a9683c343a92f4ff31f4fa1fc0a718e99` after the complete release gate.
+> The prior `0.3.1` release remains available as an immutable historical
+> release. Native Android core, Views, and
 > Compose `0.1.1` artifacts
 > are signed and public on Maven Central, with a verified sample and evidence
 > bundle in the
@@ -172,9 +174,9 @@ reordering and shaping; BidiLens supplies the application structure they need.
 
 All public packages are ESM-only, require maintained Node.js 22.12 or newer for
 server-side use, include declarations, a package README, license, and runnable example.
-Browser packages target current standards-based browsers. The complete `0.3.1`
+Browser packages target current standards-based browsers. The complete `0.3.2`
 package set is [published under the `@bidilens` npm scope](https://www.npmjs.com/org/bidilens);
-the aligned `0.3.2` source candidate is not a public registry release yet.
+the prior `0.3.1` set remains available as a reproducible historical release.
 
 ## Consumer install
 
@@ -196,7 +198,7 @@ For a no-build browser page, the published Web Component also exposes a
 standalone entry that bundles the core and needs no import map:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.1"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.2"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 

--- a/docs/OUTREACH.md
+++ b/docs/OUTREACH.md
@@ -1,6 +1,6 @@
 # Maintainer outreach kit
 
-BidiLens web `0.3.1` and signed Android `0.1.1` are published for source review
+BidiLens web `0.3.2` and signed Android `0.1.1` are published for source review
 and bounded pilots. Android has emulator and public-consumer evidence;
 physical-device/OEM/IME/TalkBack and production validation remain pending.
 Neither availability is evidence of adoption. Contact maintainers with one
@@ -46,7 +46,7 @@ Thank you,
 
 - Problem and quick start: [README](../README.md)
 - Published packages: [`@bidilens` on npm](https://www.npmjs.com/org/bidilens)
-- Versioned web release: [`v0.3.1` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.1)
+- Versioned web release: [`v0.3.2` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2)
 - Versioned Android release: [`android-v0.1.1` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1)
 - Native Android integration: [Android guide](../android/README.md)
 - Apple integration: [SwiftUI/UIKit guide](../apple/README.md)
@@ -69,7 +69,7 @@ pnpm run test:visual
 pnpm run release:check
 ```
 
-For an initial web review, install `@bidilens/core@0.3.1`; for Android, use one
+For an initial web review, install `@bidilens/core@0.3.2`; for Android, use one
 exact `io.github.codeinscrubs.bidilens:*:0.1.1` coordinate. Ask for confirmation
 of the host bug, feedback on the API boundary, or permission to prepare a small
 draft pull request. Do not claim universal rendering, zero defects,

--- a/docs/OUTREACH_LOG.md
+++ b/docs/OUTREACH_LOG.md
@@ -221,6 +221,22 @@ This is release and repository-maintenance evidence only. Hermes and Cline
 remain unmerged external submissions, Streamdown remains the one recorded
 upstream merge, and no additional company adoption is claimed.
 
+### 0.3.2 release completion update (2026-09-01)
+
+The release-preparation PR [#72](https://github.com/CodeinScrubs/BidiLens/pull/72)
+passed every required CI and CodeQL context and merged into protected `main` at
+`97f4827a9683c343a92f4ff31f4fa1fc0a718e99`. Protected publication run
+[`33508856274`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33508856274)
+published all twelve `@bidilens/*@0.3.2` packages through OIDC trusted
+publishing. Independent checks confirmed `latest@0.3.2`, matching registry
+integrity, SLSA provenance, and retained tarball SHA-256 values. The annotated
+[`v0.3.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2)
+release is immutable and retains all twelve tarballs, the release manifest, and
+a CycloneDX 1.7 SBOM; GitHub asset digests match the retained files.
+
+This update records release evidence only. External outreach threads were not
+changed, and no adoption, endorsement, or universal-rendering claim is made.
+
 ## Deliberate deferrals
 
 | Project/channel | Decision | Reason |

--- a/docs/PROJECT_COMPARISON.md
+++ b/docs/PROJECT_COMPARISON.md
@@ -186,7 +186,7 @@ lockfile install:
   pin in the security self-scan job prevents that job from reaching its scan;
 - the declared GitHub repository does not exist and npm returns `E404` for
   both `@bidiguard/core` and `@bidiguard/react-native`. Canonical BidiLens is
-  public and its 12 packages resolve at version `0.3.1`.
+  public and its 12 packages resolve at version `0.3.2`.
 
 Passing tests also miss release- and behavior-critical defects reproduced
 against the built sibling artifacts:
@@ -329,7 +329,7 @@ interest.
 A score of 100 would be false today. Even the canonical web artifact cannot
 prove historical “first” status, absence of every defect, or acceptance by a
 large AI company from local source alone. Its lead is reproducible within this
-folder: it is the only candidate here with all local release gates, safe packed
+folder: it is the only local project here with all local release gates, safe packed
 consumers, current reproducible Unicode data, meaningful security properties,
 three-engine visual/behavior tests, and explicit evidence boundaries.
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -2,7 +2,8 @@
 
 The canonical source is published at
 [`CodeinScrubs/BidiLens`](https://github.com/CodeinScrubs/BidiLens). This
-checklist records the completed web/npm `0.3.1` and Android/Maven `0.1.1`
+checklist records the completed web/npm `0.3.2` (with `0.3.1` retained as a
+historical release) and Android/Maven `0.1.1`
 releases and the controls required for future releases.
 
 ## Android distribution boundary
@@ -79,13 +80,13 @@ version.
 - MIT project license plus Unicode and imported-corpus notices;
 - human-controlled release preparation and protected npm publication
   workflows;
-- all 12 `@bidilens/*@0.3.1` packages published publicly with SLSA provenance;
+- all 12 `@bidilens/*@0.3.2` packages published publicly with SLSA provenance;
 - retained release tarballs whose SHA-512 values match the public registry;
 - per-package GitHub OIDC trusted publishers bound to `publish.yml` and the
   protected `npm-release` environment;
 - token-based publishing disabled through npm's recommended
   `Require two-factor authentication and disallow tokens` package setting;
-- annotated `v0.3.1` tag and immutable GitHub release for the exact published
+- annotated `v0.3.2` tag and immutable GitHub release for the exact published
   source commit, with all package tarballs, release manifest, and SBOM attached;
 - signed Android `0.1.1` artifacts published under the verified
   `io.github.codeinscrubs.bidilens` namespace, with protected release evidence,
@@ -100,6 +101,18 @@ version.
 - decide whether the ESM-only boundary is acceptable for target adopters.
 
 On 2026-09-01, protected publication run
+[`33508856274`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33508856274)
+published all 12 version `0.3.2` packages from exact commit
+`97f4827a9683c343a92f4ff31f4fa1fc0a718e99` through GitHub OIDC trusted
+publishing. Every package resolved as `latest@0.3.2` with matching registry
+SHA-512 integrity and SLSA provenance. The retained tarball SHA-256 values
+matched the publication manifest, and the annotated
+[`v0.3.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2) tag
+resolves to the same commit. Its immutable release contains the 12 exact
+tarballs, release manifest, and CycloneDX 1.7 SBOM; GitHub records a SHA-256
+digest for every attached asset.
+
+The earlier protected publication run
 [`33473857928`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33473857928)
 published all 12 version `0.3.1` packages from exact commit
 `7bd93c83e43b91923e7f8cf6685264b433c662b8` through GitHub OIDC trusted

--- a/docs/REQUIREMENT_MATRIX.md
+++ b/docs/REQUIREMENT_MATRIX.md
@@ -136,7 +136,7 @@ recorded explicitly.
 | CI: VS Code and native builds | Partial | Android unit/lint/AAR/APK and API 35 device jobs are pinned and executable; signed Android publication has an isolated-consumer gate; Apple Swift/macOS/iOS Simulator, Windows .NET/WPF, and native Rust three-OS jobs have hosted compiler/test evidence. VS Code and unimplemented native-platform adapters remain open |
 | Changesets and human-controlled release workflow | Complete | Changesets configuration, opt-in web release preparation, protected manual npm publication with exact confirmation and provenance, and protected manual Maven Central publication with signing and version-reuse rejection |
 | Clean packed consumer | Complete and tested | `pnpm run release:check` passes from the reviewed clean commit: all 12 packages build, pack, inspect, install into a strict consumer, import at runtime, and execute their exact packed examples |
-| Registry ownership, provenance, public repo metadata, credentials | Complete for the published package set | Canonical GitHub metadata, `@bidilens` ownership, and `io.github.codeinscrubs` namespace verified; all 12 npm `0.3.1` packages are public with SLSA provenance and matching integrity; all three Android `0.1.1` modules are signed and public with matching Central artifacts, signatures, and checksums; release credentials are protected outside the repository |
+| Registry ownership, provenance, public repo metadata, credentials | Complete for the published package set | Canonical GitHub metadata, `@bidilens` ownership, and `io.github.codeinscrubs` namespace verified; all 12 npm `0.3.2` packages are public with SLSA provenance and matching integrity; all three Android `0.1.1` modules are signed and public with matching Central artifacts, signatures, and checksums; release credentials are protected outside the repository |
 | Name/trademark decision | Partial/external | ADR records provisional `BidiLens`; final registry/legal review is still required |
 
 ## Milestone gate status
@@ -155,7 +155,7 @@ tag. Therefore working code alone cannot make an historical milestone green.
 | M6 ≥300/visual/copy | Implemented; historical gate incomplete | 932 corpus cases and 30 three-engine visual tests pass; no `m6` tag |
 | M7 native + terminal | Partial | Terminal, Android, SwiftUI/UIKit, and .NET/WPF exist; Flutter, React Native, and other documented native adapters remain open; no `m7` tag |
 | M8 playground/full EN/FA docs | Implemented; historical gate incomplete | Offline bilingual playground and EN/FA repository docs pass build/browser/link checks; no annotated `m8` tag |
-| M9 release/integrations | Partial | Package release side is complete: clean committed checkout, public npm artifacts, provenance, trusted publishing, SBOM, retained manifest, immutable `v0.3.1` web release, and signed `android-v0.1.1` Maven release. One host-tested native implementation merged upstream, but the required three integrations, downstream pilots, and adoption evidence remain incomplete |
+| M9 release/integrations | Partial | Package release side is complete: clean committed checkout, public npm artifacts, provenance, trusted publishing, SBOM, retained manifest, immutable `v0.3.2` web release, and signed `android-v0.1.1` Maven release. One host-tested native implementation merged upstream, but the required three integrations, downstream pilots, and adoption evidence remain incomplete |
 
 ## Definition-of-done audit
 
@@ -175,7 +175,7 @@ tag. Therefore working code alone cannot make an historical milestone green.
 | 12 | Complete for current packages — workflows validate, SBOM/license/notices exist |
 | 13 | Partial — one host-tested native implementation is merged; fewer than three integrations exist and no downstream pilot is evidenced |
 | 14 | Complete for current documented claims; continue checking after every change |
-| 15 | Partial — the reviewed source, current `v0.3.1` web release, and `android-v0.1.1` Maven release are public, but historical intermediate milestone tags were not fabricated retroactively |
+| 15 | Partial — the reviewed source, current `v0.3.2` web release, and `android-v0.1.1` Maven release are public, but historical intermediate milestone tags were not fabricated retroactively |
 
 ## Prior-attempt idea coverage
 

--- a/docs/V1_BUILD_REPORT.md
+++ b/docs/V1_BUILD_REPORT.md
@@ -1,23 +1,23 @@
 # BidiLens current verification and release report
 
-> This report separates the current `0.3.2` candidate evidence from immutable
-> publication history. Web/package `0.3.1` is the latest verified public
-> release; `0.3.2` remains unpublished until protected verification. Historical
-> release evidence is retained by the protected publication workflows and
-> GitHub releases linked below.
+> This report separates the current `0.3.2` release evidence from immutable
+> publication history. Web/package `0.3.2` is the latest verified public
+> release; the prior `0.3.1` release is retained as historical evidence.
+> Publication evidence is retained by the protected workflow and GitHub release
+> linked below.
 
 **Current-tree evidence date:** 2026-09-01
 
 **License:** MIT, with Unicode-data and Apache-2.0 corpus third-party notices
 
-**Publication status:** all 12 `0.3.1` packages are public with verified
-registry integrity, `latest` tags, and SLSA provenance; the exact source commit
-has an annotated `v0.3.1` tag and an immutable GitHub release containing the
-retained tarballs, release manifest, and validated SBOM. The native Android
-`0.1.1` core, Views, and Compose modules are signed and public on Maven Central
-with an annotated tag, immutable release, and public-consumer evidence. The
-`0.3.2` source and package manifests are not public until the protected release
-workflow completes.
+**Publication status:** all 12 `0.3.2` packages are public with verified
+registry integrity, `latest` tags, and SLSA provenance; exact source commit
+`97f4827a9683c343a92f4ff31f4fa1fc0a718e99` has an annotated `v0.3.2` tag and an
+immutable GitHub release containing the retained tarballs, release manifest,
+and CycloneDX 1.7 SBOM. The prior `0.3.1` release remains immutable and
+reproducible. The native Android `0.1.1` core, Views, and Compose modules are
+signed and public on Maven Central with an annotated tag, immutable release, and
+public-consumer evidence.
 
 **Recommendation:** suitable for bounded, maintainer-controlled web pilots;
 not a universal cross-platform production release
@@ -87,11 +87,10 @@ opposite-direction runs.
 | Supported Node probes | built core and CLI pass Node 22.22.1 and 24.18.0; an additional Node 20.19.5 compatibility probe passed, but that EOL line is not a production support claim |
 | Packed framework peer probes | shipped examples pass React/React DOM 18.3.1, Vue/server-renderer 3.5.0, and Svelte 4.2.20; the primary consumer covers React 19.2.8, Vue 3.5.40, and Svelte 5 |
 | `pnpm run release:check` | strict clean-worktree build/pack/inspect/install/type/runtime/CLI consumer passes; exact examples extracted from all 12 tarballs execute. The pre-commit development tree also passed with `--allow-dirty` |
-| `pnpm run npm:release:dry-run -- --version 0.3.2` | all 12 aligned tarballs packed successfully and every `0.3.2` registry coordinate was unused; no registry mutation occurred |
-| GitHub CI for published commit | [release-source CI passed](https://github.com/CodeinScrubs/BidiLens/actions/runs/31723150097) before protected `0.3.1` publication |
-| Current merged-feature gates | [PR #57](https://github.com/CodeinScrubs/BidiLens/pull/57) passed all 24 required contexts: Node 22/24, packed consumers, Windows/macOS, three browser engines, Android API 35, Apple, Windows/.NET, Rust on three OSes, audit/SBOM, workflow lint, Markdown-It 13/14/15, and five-language CodeQL |
-| Protected npm publication | [workflow run `33473857928`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33473857928) passed the full release gate, published all 12 `0.3.1` packages through OIDC trusted publishing, verified registry integrity, and retained the exact tarballs and manifest |
-| Immutable GitHub release | [`v0.3.1`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.1) resolves to published commit `7bd93c83e43b91923e7f8cf6685264b433c662b8`; GitHub reports the release immutable and records SHA-256 digests for all 12 package tarballs, the release manifest, and validated SBOM |
+| `pnpm run npm:release:dry-run -- --version 0.3.2` | all 12 aligned tarballs packed successfully before publication; no registry mutation occurred |
+| GitHub CI for release PR | [PR #72 CI](https://github.com/CodeinScrubs/BidiLens/actions/runs/33505389242) passed all 24 required contexts, including Node 22/24, packed consumers, Windows/macOS, three browser engines, Android API 35, Apple, Windows/.NET, Rust on three OSes, audit/SBOM, workflow lint, Markdown-It 13/14/15, and five-language CodeQL |
+| Protected npm publication | [workflow run `33508856274`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33508856274) passed the full release gate, published all 12 `0.3.2` packages through OIDC trusted publishing, verified registry integrity/provenance, and retained the exact tarballs and manifest |
+| Immutable GitHub release | [`v0.3.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2) resolves to published commit `97f4827a9683c343a92f4ff31f4fa1fc0a718e99`; GitHub reports the release immutable and records SHA-256 digests for all 12 package tarballs, the release manifest, and CycloneDX 1.7 SBOM |
 | External npm consumer | all 12 public packages installed from the registry; runtime imports, mixed Persian/English direction, streaming, CLI, and the pure-LTR no-op passed; current production dependency audit reported zero findings |
 | Android release CI | [13/13 jobs passed](https://github.com/CodeinScrubs/BidiLens/actions/runs/30337482079), including Android libraries/sample, isolated Maven consumer, and API 35 device tests |
 | Protected Android publication | [workflow run `30339097846`](https://github.com/CodeinScrubs/BidiLens/actions/runs/30339097846) signed and published all three Android `0.1.1` modules to Maven Central |
@@ -210,10 +209,10 @@ native/desktop ideas found in sibling documentation are retained in the
 
 ## Release decision
 
-The `0.3.1` code artifacts are published as a **maintainer-controlled public
+The `0.3.2` code artifacts are published as a **maintainer-controlled public
 web beta**. npm publication, package provenance, registry-integrity
 verification, per-package trusted publishing, protected human approval, the
-annotated `v0.3.1` tag, and the immutable release are complete. Broad rollout
+annotated `v0.3.2` tag, and the immutable release are complete. Broad rollout
 still requires:
 
 1. final name/trademark review appropriate to the adopter;
@@ -228,6 +227,6 @@ and TalkBack validation, physical iOS/VoiceOver and Windows accessibility/IME
 labs, native registry publication beyond Android, PDF support, upstream
 integrations, native-speaker certification, an external security audit, and a
 real downstream pilot remain absent. Historical milestone tags between `m1`
-and the current `v0.3.1` release tag were not retroactively fabricated;
+and the current `v0.3.2` release tag were not retroactively fabricated;
 publishing the reviewed source does not reconstruct the original stepwise tag
 history.


### PR DESCRIPTION
## Summary
- update English/Persian README and release/status docs from unpublished 0.3.2 candidate to the public immutable v0.3.2 release
- record protected publish workflow 33508856274, merge commit 97f4827a, registry/provenance verification, and release assets
- preserve 0.3.1 and historical outreach evidence as historical records

## Verification
- pnpm run docs:check
- pnpm run check (437 tests, build, corpus, Action checks)

Documentation only; published package contents are unchanged.