### PR TITLE
ci: allow cold Swift CodeQL builds to finish

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,7 +80,11 @@ jobs:
   swift:
     name: CodeQL (swift)
     runs-on: macos-latest
-    timeout-minutes: 40
+    # Xcode simulator builds are instrumented by CodeQL and can exceed 40
+    # minutes on a cold macOS runner. Keep the security gate intact while
+    # allowing database finalization to complete instead of producing a
+    # misleading timeout failure.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Why

The Swift CodeQL job completed the full Xcode package/iOS build on `main`, but CodeQL database finalization was canceled at the existing 40-minute job timeout. This creates a false security-gate failure on cold `macos-latest` runners.

## Change

- Raise only the Swift CodeQL job timeout from 40 to 60 minutes.
- Keep the same checkout, build, CodeQL queries, and required status context.
- No product/runtime behavior changes.

## Evidence

- Main run 33512060719: Xcode build succeeded; CodeQL finalization was canceled at 40 minutes.
- Identical Swift scans have passed previously in 17–27 minutes, so this preserves the gate while covering runner variance.
- `git diff --check` passes.
