### PR TITLE
fix: preserve native adapter property ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ is published under the public `@bidilens` npm scope.
   Unicode combining mark inside its neighboring opposite-direction isolate,
   matching the TypeScript core and preventing visible grapheme loss in Persian,
   Arabic, Hebrew, and other marked scripts.
+- Android Views, editable UIKit, and WPF adapters now adopt observable host
+  direction/alignment changes made during a managed session instead of later
+  restoring stale values. WPF updates also retain existing dependency-property
+  bindings, Android exposes an explicit same-value ownership handoff, and
+  editable UIKit now leaves distinct paragraph state untouched on pure LTR
+  no-op paths.
 
 ## 0.3.2 - 2026-09-01
 

--- a/android/README.md
+++ b/android/README.md
@@ -128,6 +128,10 @@ titleTextView.applyBidiLens(alignToContent = false)
 
 Switching `alignToContent` from `true` to `false` restores the original
 alignment/gravity immediately while retaining the detected text direction.
+Observable application changes to direction, alignment, or gravity made while
+a view is managed become its new authored state. Before deliberately taking
+ownership with the same value BidiLens is currently rendering, call
+`titleTextView.restoreBidiLens()` and then apply the application value.
 
 For an editable field:
 

--- a/android/views/src/main/kotlin/io/github/codeinscrubs/bidilens/views/BidiTextView.kt
+++ b/android/views/src/main/kotlin/io/github/codeinscrubs/bidilens/views/BidiTextView.kt
@@ -23,30 +23,67 @@ import io.github.codeinscrubs.bidilens.core.isolateText
 fun Context.supportsBidiLensRtl(): Boolean =
     applicationInfo.flags and ApplicationInfo.FLAG_SUPPORTS_RTL != 0
 
-private data class OriginalTextViewState(
+private data class TextViewProperties(
     val textDirection: Int,
     val textAlignment: Int,
     val gravity: Int,
 )
 
-private fun TextView.originalState(): OriginalTextViewState? =
-    getTag(R.id.bidilens_original_view_state) as? OriginalTextViewState
+private data class ManagedTextViewState(
+    var original: TextViewProperties,
+    var rendered: TextViewProperties? = null,
+)
 
-private fun TextView.rememberOriginalState() {
-    if (originalState() == null) {
-        setTag(
-            R.id.bidilens_original_view_state,
-            OriginalTextViewState(textDirection, textAlignment, gravity),
-        )
+private fun TextView.properties(): TextViewProperties =
+    TextViewProperties(textDirection, textAlignment, gravity)
+
+private fun TextView.managedState(): ManagedTextViewState? =
+    getTag(R.id.bidilens_original_view_state) as? ManagedTextViewState
+
+private fun TextView.reconcileHostChanges(state: ManagedTextViewState) {
+    val rendered = state.rendered ?: return
+    val current = properties()
+    state.original = TextViewProperties(
+        textDirection = if (current.textDirection != rendered.textDirection) {
+            current.textDirection
+        } else {
+            state.original.textDirection
+        },
+        textAlignment = if (current.textAlignment != rendered.textAlignment) {
+            current.textAlignment
+        } else {
+            state.original.textAlignment
+        },
+        gravity = if (current.gravity != rendered.gravity) current.gravity else state.original.gravity,
+    )
+}
+
+private fun TextView.rememberOriginalState(): ManagedTextViewState {
+    managedState()?.let {
+        reconcileHostChanges(it)
+        return it
+    }
+    return ManagedTextViewState(original = properties()).also {
+        setTag(R.id.bidilens_original_view_state, it)
     }
 }
 
 private fun TextView.restoreOriginalState() {
-    val state = originalState() ?: return
-    textDirection = state.textDirection
-    textAlignment = state.textAlignment
-    gravity = state.gravity
+    val state = managedState() ?: return
+    reconcileHostChanges(state)
+    textAlignment = state.original.textAlignment
+    gravity = state.original.gravity
+    textDirection = state.original.textDirection
     setTag(R.id.bidilens_original_view_state, null)
+}
+
+/**
+ * Restores properties still owned by BidiLens and ends the current managed
+ * session. Call this before an intentional same-value property handoff, which
+ * Android does not expose as an observable mutation.
+ */
+fun TextView.restoreBidiLens() {
+    restoreOriginalState()
 }
 
 private fun TextView.applyAnalysis(
@@ -57,7 +94,7 @@ private fun TextView.applyAnalysis(
         restoreOriginalState()
         return
     }
-    rememberOriginalState()
+    val state = rememberOriginalState()
     if (alignToContent) {
         textAlignment = View.TEXT_ALIGNMENT_GRAVITY
         val horizontal = if (analysis.resolvedDirection == BidiDirection.RTL) {
@@ -69,9 +106,8 @@ private fun TextView.applyAnalysis(
     } else {
         // Direction and alignment are independent. A caller may switch an
         // already-managed RTL value back to its authored physical alignment.
-        val original = originalState() ?: return
-        textAlignment = original.textAlignment
-        gravity = original.gravity
+        textAlignment = state.original.textAlignment
+        gravity = state.original.gravity
     }
     // Android alignment/gravity setters can recalculate text-direction state.
     // Apply the paragraph base last so physical alignment remains independent.
@@ -80,6 +116,7 @@ private fun TextView.applyAnalysis(
         BidiDirection.LTR -> View.TEXT_DIRECTION_LTR
         BidiDirection.NEUTRAL -> View.TEXT_DIRECTION_INHERIT
     }
+    state.rendered = properties()
 }
 
 /**

--- a/android/views/src/test/kotlin/io/github/codeinscrubs/bidilens/views/BidiTextViewTest.kt
+++ b/android/views/src/test/kotlin/io/github/codeinscrubs/bidilens/views/BidiTextViewTest.kt
@@ -90,6 +90,59 @@ class BidiTextViewTest {
     }
 
     @Test
+    fun hostPropertyChangesWhileManagedBecomeTheNewAuthoredState() {
+        val view = TextView(context).apply {
+            text = "سلام دنیا"
+            textDirection = View.TEXT_DIRECTION_LOCALE
+            textAlignment = View.TEXT_ALIGNMENT_GRAVITY
+            gravity = Gravity.LEFT or Gravity.CENTER_VERTICAL
+        }
+        view.applyBidiLens(alignToContent = true)
+        val managedDirection = view.textDirection
+
+        // Application code deliberately updates two independently owned
+        // properties while BidiLens still owns the rendered RTL state.
+        view.textDirection = View.TEXT_DIRECTION_FIRST_STRONG
+        val authoredDirection = view.textDirection
+        view.gravity = Gravity.CENTER_HORIZONTAL or Gravity.CENTER_VERTICAL
+        view.applyBidiLens(alignToContent = false)
+
+        assertEquals(managedDirection, view.textDirection)
+        assertEquals(Gravity.CENTER_HORIZONTAL, view.gravity and Gravity.HORIZONTAL_GRAVITY_MASK)
+
+        view.text = "English only"
+        view.applyBidiLens()
+
+        assertEquals(authoredDirection, view.textDirection)
+        assertEquals(Gravity.CENTER_HORIZONTAL, view.gravity and Gravity.HORIZONTAL_GRAVITY_MASK)
+        assertNull(view.getTag(R.id.bidilens_original_view_state))
+    }
+
+    @Test
+    fun explicitRestoreAllowsSameValueOwnershipHandoff() {
+        val view = TextView(context).apply {
+            text = "سلام دنیا"
+            textDirection = View.TEXT_DIRECTION_LOCALE
+            textAlignment = View.TEXT_ALIGNMENT_GRAVITY
+            gravity = Gravity.LEFT
+        }
+        view.applyBidiLens()
+        val renderedDirection = view.textDirection
+        val renderedGravity = view.gravity
+
+        view.restoreBidiLens()
+        view.textDirection = renderedDirection
+        view.gravity = renderedGravity
+        view.applyBidiLens()
+        view.text = "English only"
+        view.applyBidiLens()
+
+        assertEquals(renderedDirection, view.textDirection)
+        assertEquals(renderedGravity, view.gravity)
+        assertNull(view.getTag(R.id.bidilens_original_view_state))
+    }
+
+    @Test
     fun mixedPersianSourceKeepsLogicalString() {
         val source = "از جلد سه qb، page 97"
         val view = TextView(context).apply { text = source }

--- a/apple/README.md
+++ b/apple/README.md
@@ -47,6 +47,12 @@ This keeps an RTL Persian paragraph physically aligned to the left while its
 base writing direction remains RTL. Source text and editable selection are
 preserved.
 
+Editable UIKit adapters adopt observable host changes to `textAlignment` and
+base writing direction between calls, then restore those authored values when
+intervention ends. If application code intentionally takes ownership with the
+same value BidiLens is already rendering, call `BidiUIKit.restore(...)` before
+the handoff.
+
 Add the repository as a Swift Package in Xcode and select the `BidiLens`
 library. The package intentionally does not force the layout direction of a
 screen or mirror unrelated controls.

--- a/apple/README.md
+++ b/apple/README.md
@@ -51,7 +51,8 @@ Editable UIKit adapters adopt observable host changes to `textAlignment` and
 base writing direction between calls, then restore those authored values when
 intervention ends. If application code intentionally takes ownership with the
 same value BidiLens is already rendering, call `BidiUIKit.restore(...)` before
-the handoff.
+the handoff. When no intervention is required, editable UIKit paragraph state
+is left untouched.
 
 Add the repository as a Swift Package in Xcode and select the `BidiLens`
 library. The package intentionally does not force the layout direction of a

--- a/apple/README.md
+++ b/apple/README.md
@@ -47,12 +47,13 @@ This keeps an RTL Persian paragraph physically aligned to the left while its
 base writing direction remains RTL. Source text and editable selection are
 preserved.
 
-Editable UIKit adapters adopt observable host changes to `textAlignment` and
-base writing direction between calls, then restore those authored values when
-intervention ends. If application code intentionally takes ownership with the
-same value BidiLens is already rendering, call `BidiUIKit.restore(...)` before
-the handoff. When no intervention is required, editable UIKit paragraph state
-is left untouched.
+Editable UIKit adapters adopt observable host changes to `textAlignment` and,
+while the source text is unchanged, base writing direction between calls. They
+then restore those authored values when intervention ends. UIKit reports base
+direction through text positions, so call `BidiUIKit.restore(...)` before
+changing text and authored direction together, or before intentionally taking
+ownership with the same value BidiLens is already rendering. When no
+intervention is required, editable UIKit paragraph state is left untouched.
 
 Add the repository as a Swift Package in Xcode and select the `BidiLens`
 library. The package intentionally does not force the layout direction of a

--- a/apple/Sources/BidiLens/UIKitAdapters.swift
+++ b/apple/Sources/BidiLens/UIKitAdapters.swift
@@ -144,15 +144,15 @@ public enum BidiUIKit {
         let source = textView.text ?? ""
         let selection = textView.selectedRange
         let analysis = BidiAnalyzer.analyze(source, options: options)
+        if !analysis.interventionRequired {
+            restore(textView)
+            return analysis
+        }
         let state = inputState(
             textView,
             key: &textViewStateKey,
             alignment: textView.textAlignment
         )
-        if !analysis.interventionRequired {
-            restore(textView)
-            return analysis
-        }
 
         textView.textAlignment = uiAlignment(
             alignment,
@@ -172,6 +172,8 @@ public enum BidiUIKit {
         return analysis
     }
 
+    /// Restores authored input properties and ends the managed session.
+    /// Call before an intentional same-value property ownership handoff.
     public static func restore(_ textView: UITextView) {
         guard let state = objc_getAssociatedObject(
             textView,
@@ -200,15 +202,15 @@ public enum BidiUIKit {
         let source = textField.text ?? ""
         let selection = textField.selectedTextRange
         let analysis = BidiAnalyzer.analyze(source, options: options)
+        if !analysis.interventionRequired {
+            restore(textField)
+            return analysis
+        }
         let state = inputState(
             textField,
             key: &textFieldStateKey,
             alignment: textField.textAlignment
         )
-        if !analysis.interventionRequired {
-            restore(textField)
-            return analysis
-        }
 
         textField.textAlignment = uiAlignment(
             alignment,
@@ -228,6 +230,8 @@ public enum BidiUIKit {
         return analysis
     }
 
+    /// Restores authored input properties and ends the managed session.
+    /// Call before an intentional same-value property ownership handoff.
     public static func restore(_ textField: UITextField) {
         guard let state = objc_getAssociatedObject(
             textField,

--- a/apple/Sources/BidiLens/UIKitAdapters.swift
+++ b/apple/Sources/BidiLens/UIKitAdapters.swift
@@ -29,8 +29,10 @@ public enum BidiUIKit {
     }
 
     private final class InputState: NSObject {
-        let alignment: NSTextAlignment
-        let direction: NSWritingDirection
+        var alignment: NSTextAlignment
+        var direction: NSWritingDirection
+        var renderedAlignment: NSTextAlignment?
+        var renderedDirection: NSWritingDirection?
 
         init(alignment: NSTextAlignment, direction: NSWritingDirection) {
             self.alignment = alignment
@@ -166,6 +168,7 @@ public enum BidiUIKit {
             )
         }
         textView.selectedRange = selection
+        markInputRendered(textView, state: state, alignment: textView.textAlignment)
         return analysis
     }
 
@@ -175,6 +178,7 @@ public enum BidiUIKit {
             &textViewStateKey
         ) as? InputState else { return }
         let selection = textView.selectedRange
+        reconcileInputState(textView, state: state, alignment: textView.textAlignment)
         textView.textAlignment = state.alignment
         setWritingDirection(state.direction, on: textView, source: textView.text ?? "")
         textView.selectedRange = selection
@@ -220,6 +224,7 @@ public enum BidiUIKit {
             )
         }
         textField.selectedTextRange = selection
+        markInputRendered(textField, state: state, alignment: textField.textAlignment)
         return analysis
     }
 
@@ -229,6 +234,7 @@ public enum BidiUIKit {
             &textFieldStateKey
         ) as? InputState else { return }
         let selection = textField.selectedTextRange
+        reconcileInputState(textField, state: state, alignment: textField.textAlignment)
         textField.textAlignment = state.alignment
         setWritingDirection(state.direction, on: textField, source: textField.text ?? "")
         textField.selectedTextRange = selection
@@ -246,6 +252,7 @@ public enum BidiUIKit {
         alignment: NSTextAlignment
     ) -> InputState {
         if let state = objc_getAssociatedObject(input, key) as? InputState {
+            reconcileInputState(input, state: state, alignment: alignment)
             return state
         }
         let start = input.beginningOfDocument
@@ -255,6 +262,37 @@ public enum BidiUIKit {
         )
         objc_setAssociatedObject(input, key, state, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return state
+    }
+
+    private static func reconcileInputState(
+        _ input: UITextInput,
+        state: InputState,
+        alignment: NSTextAlignment
+    ) {
+        if let renderedAlignment = state.renderedAlignment,
+           alignment != renderedAlignment {
+            state.alignment = alignment
+        }
+        let currentDirection = input.baseWritingDirection(
+            for: input.beginningOfDocument,
+            in: .forward
+        )
+        if let renderedDirection = state.renderedDirection,
+           currentDirection != renderedDirection {
+            state.direction = currentDirection
+        }
+    }
+
+    private static func markInputRendered(
+        _ input: UITextInput,
+        state: InputState,
+        alignment: NSTextAlignment
+    ) {
+        state.renderedAlignment = alignment
+        state.renderedDirection = input.baseWritingDirection(
+            for: input.beginningOfDocument,
+            in: .forward
+        )
     }
 
     private static func setWritingDirection(

--- a/apple/Sources/BidiLens/UIKitAdapters.swift
+++ b/apple/Sources/BidiLens/UIKitAdapters.swift
@@ -33,6 +33,7 @@ public enum BidiUIKit {
         var direction: NSWritingDirection
         var renderedAlignment: NSTextAlignment?
         var renderedDirection: NSWritingDirection?
+        var renderedSource: String?
 
         init(alignment: NSTextAlignment, direction: NSWritingDirection) {
             self.alignment = alignment
@@ -151,7 +152,8 @@ public enum BidiUIKit {
         let state = inputState(
             textView,
             key: &textViewStateKey,
-            alignment: textView.textAlignment
+            alignment: textView.textAlignment,
+            source: source
         )
 
         textView.textAlignment = uiAlignment(
@@ -168,7 +170,12 @@ public enum BidiUIKit {
             )
         }
         textView.selectedRange = selection
-        markInputRendered(textView, state: state, alignment: textView.textAlignment)
+        markInputRendered(
+            textView,
+            state: state,
+            alignment: textView.textAlignment,
+            source: source
+        )
         return analysis
     }
 
@@ -180,9 +187,15 @@ public enum BidiUIKit {
             &textViewStateKey
         ) as? InputState else { return }
         let selection = textView.selectedRange
-        reconcileInputState(textView, state: state, alignment: textView.textAlignment)
+        let source = textView.text ?? ""
+        reconcileInputState(
+            textView,
+            state: state,
+            alignment: textView.textAlignment,
+            source: source
+        )
         textView.textAlignment = state.alignment
-        setWritingDirection(state.direction, on: textView, source: textView.text ?? "")
+        setWritingDirection(state.direction, on: textView, source: source)
         textView.selectedRange = selection
         objc_setAssociatedObject(
             textView,
@@ -209,7 +222,8 @@ public enum BidiUIKit {
         let state = inputState(
             textField,
             key: &textFieldStateKey,
-            alignment: textField.textAlignment
+            alignment: textField.textAlignment,
+            source: source
         )
 
         textField.textAlignment = uiAlignment(
@@ -226,7 +240,12 @@ public enum BidiUIKit {
             )
         }
         textField.selectedTextRange = selection
-        markInputRendered(textField, state: state, alignment: textField.textAlignment)
+        markInputRendered(
+            textField,
+            state: state,
+            alignment: textField.textAlignment,
+            source: source
+        )
         return analysis
     }
 
@@ -238,9 +257,15 @@ public enum BidiUIKit {
             &textFieldStateKey
         ) as? InputState else { return }
         let selection = textField.selectedTextRange
-        reconcileInputState(textField, state: state, alignment: textField.textAlignment)
+        let source = textField.text ?? ""
+        reconcileInputState(
+            textField,
+            state: state,
+            alignment: textField.textAlignment,
+            source: source
+        )
         textField.textAlignment = state.alignment
-        setWritingDirection(state.direction, on: textField, source: textField.text ?? "")
+        setWritingDirection(state.direction, on: textField, source: source)
         textField.selectedTextRange = selection
         objc_setAssociatedObject(
             textField,
@@ -253,10 +278,11 @@ public enum BidiUIKit {
     private static func inputState(
         _ input: UITextInput,
         key: UnsafeRawPointer,
-        alignment: NSTextAlignment
+        alignment: NSTextAlignment,
+        source: String
     ) -> InputState {
         if let state = objc_getAssociatedObject(input, key) as? InputState {
-            reconcileInputState(input, state: state, alignment: alignment)
+            reconcileInputState(input, state: state, alignment: alignment, source: source)
             return state
         }
         let start = input.beginningOfDocument
@@ -271,7 +297,8 @@ public enum BidiUIKit {
     private static func reconcileInputState(
         _ input: UITextInput,
         state: InputState,
-        alignment: NSTextAlignment
+        alignment: NSTextAlignment,
+        source: String
     ) {
         if let renderedAlignment = state.renderedAlignment,
            alignment != renderedAlignment {
@@ -281,7 +308,11 @@ public enum BidiUIKit {
             for: input.beginningOfDocument,
             in: .forward
         )
-        if let renderedDirection = state.renderedDirection,
+        // UITextInput direction is position/content-sensitive. A changed source
+        // can therefore alter the reported value without an authored property
+        // handoff, so only reconcile it within the source we rendered.
+        if state.renderedSource == source,
+           let renderedDirection = state.renderedDirection,
            currentDirection != renderedDirection {
             state.direction = currentDirection
         }
@@ -290,13 +321,15 @@ public enum BidiUIKit {
     private static func markInputRendered(
         _ input: UITextInput,
         state: InputState,
-        alignment: NSTextAlignment
+        alignment: NSTextAlignment,
+        source: String
     ) {
         state.renderedAlignment = alignment
         state.renderedDirection = input.baseWritingDirection(
             for: input.beginningOfDocument,
             in: .forward
         )
+        state.renderedSource = source
     }
 
     private static func setWritingDirection(

--- a/apple/Tests/BidiLensTests/AppleAdapterTests.swift
+++ b/apple/Tests/BidiLensTests/AppleAdapterTests.swift
@@ -296,6 +296,7 @@ final class AppleAdapterTests: XCTestCase {
             for: textView.beginningOfDocument,
             in: .forward
         )
+        XCTAssertEqual(authoredDirection, .leftToRight)
         XCTAssertNotEqual(authoredDirection, managedDirection)
         BidiUIKit.apply(to: textView, alignment: .preserve)
         XCTAssertEqual(textView.textAlignment, .center)

--- a/apple/Tests/BidiLensTests/AppleAdapterTests.swift
+++ b/apple/Tests/BidiLensTests/AppleAdapterTests.swift
@@ -231,5 +231,44 @@ final class AppleAdapterTests: XCTestCase {
         XCTAssertEqual(textField.textAlignment, .left)
         XCTAssertEqual(textField.selectedTextRange, selection)
     }
+
+    @MainActor
+    func testUIKitTextInputAdoptsHostPropertiesWhileManaged() throws {
+        let textView = UITextView()
+        textView.text = rtl
+        textView.textAlignment = .left
+        BidiUIKit.apply(to: textView, alignment: .contentStart)
+        XCTAssertEqual(textView.textAlignment, .right)
+        XCTAssertEqual(
+            textView.baseWritingDirection(for: textView.beginningOfDocument, in: .forward),
+            .rightToLeft
+        )
+
+        textView.textAlignment = .center
+        let end = try XCTUnwrap(
+            textView.position(
+                from: textView.beginningOfDocument,
+                offset: (rtl as NSString).length
+            )
+        )
+        let range = try XCTUnwrap(
+            textView.textRange(from: textView.beginningOfDocument, to: end)
+        )
+        textView.setBaseWritingDirection(.leftToRight, for: range)
+        BidiUIKit.apply(to: textView, alignment: .preserve)
+        XCTAssertEqual(textView.textAlignment, .center)
+        XCTAssertEqual(
+            textView.baseWritingDirection(for: textView.beginningOfDocument, in: .forward),
+            .rightToLeft
+        )
+
+        textView.text = ltr
+        BidiUIKit.apply(to: textView)
+        XCTAssertEqual(textView.textAlignment, .center)
+        XCTAssertEqual(
+            textView.baseWritingDirection(for: textView.beginningOfDocument, in: .forward),
+            .leftToRight
+        )
+    }
 }
 #endif

--- a/apple/Tests/BidiLensTests/AppleAdapterTests.swift
+++ b/apple/Tests/BidiLensTests/AppleAdapterTests.swift
@@ -233,16 +233,53 @@ final class AppleAdapterTests: XCTestCase {
     }
 
     @MainActor
+    func testPureLTRTextInputLeavesDistinctParagraphStateUntouched() throws {
+        let textView = UITextView()
+        let attributed = NSMutableAttributedString(string: "First\nSecond")
+        let firstParagraph = NSMutableParagraphStyle()
+        firstParagraph.alignment = .center
+        firstParagraph.baseWritingDirection = .leftToRight
+        let secondParagraph = NSMutableParagraphStyle()
+        secondParagraph.alignment = .justified
+        secondParagraph.baseWritingDirection = .rightToLeft
+        attributed.addAttribute(
+            .paragraphStyle,
+            value: firstParagraph,
+            range: NSRange(location: 0, length: 6)
+        )
+        attributed.addAttribute(
+            .paragraphStyle,
+            value: secondParagraph,
+            range: NSRange(location: 6, length: 6)
+        )
+        textView.attributedText = attributed
+        textView.textAlignment = .center
+        textView.selectedRange = NSRange(location: 7, length: 2)
+        let authored = NSAttributedString(
+            attributedString: try XCTUnwrap(textView.attributedText)
+        )
+
+        let analysis = BidiUIKit.apply(to: textView, alignment: .physicalRight)
+
+        XCTAssertFalse(analysis.interventionRequired)
+        XCTAssertEqual(textView.textAlignment, .center)
+        XCTAssertEqual(textView.selectedRange, NSRange(location: 7, length: 2))
+        let rendered = try XCTUnwrap(textView.attributedText)
+        XCTAssertTrue(rendered.isEqual(to: authored))
+    }
+
+    @MainActor
     func testUIKitTextInputAdoptsHostPropertiesWhileManaged() throws {
         let textView = UITextView()
         textView.text = rtl
         textView.textAlignment = .left
         BidiUIKit.apply(to: textView, alignment: .contentStart)
         XCTAssertEqual(textView.textAlignment, .right)
-        XCTAssertEqual(
-            textView.baseWritingDirection(for: textView.beginningOfDocument, in: .forward),
-            .rightToLeft
+        let managedDirection = textView.baseWritingDirection(
+            for: textView.beginningOfDocument,
+            in: .forward
         )
+        XCTAssertEqual(managedDirection, .rightToLeft)
 
         textView.textAlignment = .center
         let end = try XCTUnwrap(
@@ -255,11 +292,16 @@ final class AppleAdapterTests: XCTestCase {
             textView.textRange(from: textView.beginningOfDocument, to: end)
         )
         textView.setBaseWritingDirection(.leftToRight, for: range)
+        let authoredDirection = textView.baseWritingDirection(
+            for: textView.beginningOfDocument,
+            in: .forward
+        )
+        XCTAssertNotEqual(authoredDirection, managedDirection)
         BidiUIKit.apply(to: textView, alignment: .preserve)
         XCTAssertEqual(textView.textAlignment, .center)
         XCTAssertEqual(
             textView.baseWritingDirection(for: textView.beginningOfDocument, in: .forward),
-            .rightToLeft
+            managedDirection
         )
 
         textView.text = ltr
@@ -267,7 +309,7 @@ final class AppleAdapterTests: XCTestCase {
         XCTAssertEqual(textView.textAlignment, .center)
         XCTAssertEqual(
             textView.baseWritingDirection(for: textView.beginningOfDocument, in: .forward),
-            .leftToRight
+            authoredDirection
         )
     }
 }

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -122,6 +122,12 @@ Android Views, `BidiUIKit.restore(...)` on editable UIKit controls, or
 property updates; the application binding remains attached while BidiLens is
 active and after restoration.
 
+UIKit exposes editable base direction through a text position, so that value
+can change when the text changes even without a property handoff. BidiLens
+therefore adopts an observable UIKit direction change only while the source is
+unchanged. Call `BidiUIKit.restore(...)` before replacing both text and its
+authored direction.
+
 Public packages are ESM-only. CommonJS consumers must use dynamic `import()`
 or an ESM bridge. Node.js 22.12 is the declared minimum. React 18–19, Vue 3.5+, and
 Svelte 4–5 are the tested/declarative peer families; older or future majors are

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -113,10 +113,14 @@ restores its previous intervention before every update. WPF adapters preserve
 `Text` and selection and restore the original
 `FlowDirection`/`TextAlignment` when an intervention is no longer required.
 
-DOM ownership is determined from observable attribute/property changes. A
-same-value inline-style assignment made while BidiLens already owns that exact
-value cannot be distinguished from no assignment; call `restoreBidi()` before
-intentionally transferring ownership of such a property to application code.
+Imperative adapter ownership is determined from observable property changes.
+A same-value assignment made while BidiLens already renders that exact value
+cannot be distinguished from no assignment. Before intentionally transferring
+ownership, call `restoreBidi(root)` on the DOM, `view.restoreBidiLens()` on
+Android Views, `BidiUIKit.restore(...)` on editable UIKit controls, or
+`BidiWpf.Restore(control)` on WPF. WPF uses binding-preserving dependency
+property updates; the application binding remains attached while BidiLens is
+active and after restoration.
 
 Public packages are ESM-only. CommonJS consumers must use dynamic `import()`
 or an ESM bridge. Node.js 22.12 is the declared minimum. React 18–19, Vue 3.5+, and

--- a/windows/README.md
+++ b/windows/README.md
@@ -15,6 +15,10 @@ var analysis = BidiWpf.Apply(
 `TextBlock.Text` or `TextBox.Text`, and preserves `TextBox` selection.
 Unicode combining marks remain attached to their neighboring grapheme when
 mixed-direction runs are isolated.
+It applies dependency properties without detaching existing WPF bindings and
+adopts observable host changes made while a control is managed. Call
+`BidiWpf.Restore(control)` before intentionally handing off a property with the
+same value BidiLens is currently rendering.
 
 Run:
 
@@ -26,9 +30,10 @@ dotnet run --project windows/samples/BidiLens.Wpf.Sample
 
 The executable test project covers the canonical direction corpus, source and
 selection preservation, pure-LTR non-interference, and independent physical
-alignment. WinUI 3, Windows Forms, MAUI, and accessibility laboratory testing
-remain separate host-specific work; the pure core can be consumed by them
-without taking a WPF dependency.
+alignment, adapter ownership, and WPF binding preservation. WinUI 3, Windows
+Forms, MAUI, and accessibility laboratory testing remain separate
+host-specific work; the pure core can be consumed by them without taking a
+WPF dependency.
 
 The .NET core inventories bidi formatting controls and flags high-risk
 overrides. The richer balance/context diagnostics in the JavaScript and

--- a/windows/src/BidiLens.Wpf/BidiWpf.cs
+++ b/windows/src/BidiLens.Wpf/BidiWpf.cs
@@ -47,10 +47,12 @@ public static class BidiWpf
         return analysis;
     }
 
+    /// <summary>Restores authored properties and ends the managed session.</summary>
     public static void Restore(TextBlock control) => Restore(
         control,
         value => control.SetCurrentValue(TextBlock.TextAlignmentProperty, value));
 
+    /// <summary>Restores authored properties and ends the managed session.</summary>
     public static void Restore(TextBox control) => Restore(
         control,
         value => control.SetCurrentValue(TextBox.TextAlignmentProperty, value));

--- a/windows/src/BidiLens.Wpf/BidiWpf.cs
+++ b/windows/src/BidiLens.Wpf/BidiWpf.cs
@@ -6,8 +6,15 @@ namespace BidiLens.Wpf;
 
 public static class BidiWpf
 {
-    private sealed record OriginalState(FlowDirection FlowDirection, TextAlignment TextAlignment);
-    private static readonly ConditionalWeakTable<FrameworkElement, OriginalState> OriginalStates = new();
+    private sealed class ManagedState(FlowDirection flowDirection, TextAlignment textAlignment)
+    {
+        public FlowDirection OriginalFlowDirection { get; set; } = flowDirection;
+        public TextAlignment OriginalTextAlignment { get; set; } = textAlignment;
+        public FlowDirection? RenderedFlowDirection { get; set; }
+        public TextAlignment? RenderedTextAlignment { get; set; }
+    }
+
+    private static readonly ConditionalWeakTable<FrameworkElement, ManagedState> ManagedStates = new();
 
     public static BidiAnalysis Apply(
         TextBlock control,
@@ -15,7 +22,11 @@ public static class BidiWpf
         BidiAlignment alignment = BidiAlignment.ContentStart)
     {
         var analysis = BidiAnalyzer.Analyze(control.Text ?? string.Empty, options);
-        Apply(control, analysis, alignment, value => control.TextAlignment = value);
+        Apply(
+            control,
+            analysis,
+            alignment,
+            value => control.SetCurrentValue(TextBlock.TextAlignmentProperty, value));
         return analysis;
     }
 
@@ -27,14 +38,22 @@ public static class BidiWpf
         var analysis = BidiAnalyzer.Analyze(control.Text ?? string.Empty, options);
         var selectionStart = control.SelectionStart;
         var selectionLength = control.SelectionLength;
-        Apply(control, analysis, alignment, value => control.TextAlignment = value);
+        Apply(
+            control,
+            analysis,
+            alignment,
+            value => control.SetCurrentValue(TextBox.TextAlignmentProperty, value));
         control.Select(selectionStart, selectionLength);
         return analysis;
     }
 
-    public static void Restore(TextBlock control) => Restore(control, value => control.TextAlignment = value);
+    public static void Restore(TextBlock control) => Restore(
+        control,
+        value => control.SetCurrentValue(TextBlock.TextAlignmentProperty, value));
 
-    public static void Restore(TextBox control) => Restore(control, value => control.TextAlignment = value);
+    public static void Restore(TextBox control) => Restore(
+        control,
+        value => control.SetCurrentValue(TextBox.TextAlignmentProperty, value));
 
     private static void Apply(
         FrameworkElement control,
@@ -47,19 +66,15 @@ public static class BidiWpf
             Restore(control, setAlignment);
             return;
         }
-        if (!OriginalStates.TryGetValue(control, out var original))
+        if (!ManagedStates.TryGetValue(control, out var state))
         {
-            original = new(control.FlowDirection, control switch
-            {
-                TextBlock textBlock => textBlock.TextAlignment,
-                TextBox textBox => textBox.TextAlignment,
-                _ => TextAlignment.Left,
-            });
-            OriginalStates.Add(control, original);
+            state = new(control.FlowDirection, GetAlignment(control));
+            ManagedStates.Add(control, state);
         }
+        else ReconcileHostChanges(control, state);
         setAlignment(alignment switch
         {
-            BidiAlignment.Preserve => original.TextAlignment,
+            BidiAlignment.Preserve => state.OriginalTextAlignment,
             BidiAlignment.ContentStart => analysis.ResolvedDirection == BidiDirection.RightToLeft
                 ? TextAlignment.Right
                 : TextAlignment.Left,
@@ -67,18 +82,41 @@ public static class BidiWpf
             BidiAlignment.PhysicalRight => TextAlignment.Right,
             BidiAlignment.Center => TextAlignment.Center,
             BidiAlignment.Justify => TextAlignment.Justify,
-            _ => original.TextAlignment,
+            _ => state.OriginalTextAlignment,
         });
-        control.FlowDirection = analysis.ResolvedDirection == BidiDirection.RightToLeft
-            ? FlowDirection.RightToLeft
-            : FlowDirection.LeftToRight;
+        control.SetCurrentValue(
+            FrameworkElement.FlowDirectionProperty,
+            analysis.ResolvedDirection == BidiDirection.RightToLeft
+                ? FlowDirection.RightToLeft
+                : FlowDirection.LeftToRight);
+        state.RenderedTextAlignment = GetAlignment(control);
+        state.RenderedFlowDirection = control.FlowDirection;
     }
 
     private static void Restore(FrameworkElement control, Action<TextAlignment> setAlignment)
     {
-        if (!OriginalStates.TryGetValue(control, out var original)) return;
-        setAlignment(original.TextAlignment);
-        control.FlowDirection = original.FlowDirection;
-        OriginalStates.Remove(control);
+        if (!ManagedStates.TryGetValue(control, out var state)) return;
+        ReconcileHostChanges(control, state);
+        setAlignment(state.OriginalTextAlignment);
+        control.SetCurrentValue(FrameworkElement.FlowDirectionProperty, state.OriginalFlowDirection);
+        ManagedStates.Remove(control);
+    }
+
+    private static TextAlignment GetAlignment(FrameworkElement control) => control switch
+    {
+        TextBlock textBlock => textBlock.TextAlignment,
+        TextBox textBox => textBox.TextAlignment,
+        _ => TextAlignment.Left,
+    };
+
+    private static void ReconcileHostChanges(FrameworkElement control, ManagedState state)
+    {
+        var currentAlignment = GetAlignment(control);
+        if (state.RenderedTextAlignment is { } renderedAlignment
+            && currentAlignment != renderedAlignment)
+            state.OriginalTextAlignment = currentAlignment;
+        if (state.RenderedFlowDirection is { } renderedDirection
+            && control.FlowDirection != renderedDirection)
+            state.OriginalFlowDirection = control.FlowDirection;
     }
 }

--- a/windows/tests/BidiLens.Tests/Program.cs
+++ b/windows/tests/BidiLens.Tests/Program.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using BidiLens;
 using BidiLens.Wpf;
 
@@ -79,6 +80,48 @@ internal static class Program
         Equal(2, textBox.SelectionLength, "TextBox selection length");
         Equal(TextAlignment.Left, textBox.TextAlignment, "TextBox physical-left alignment");
 
+        var hostManaged = new TextBlock
+        {
+            Text = flagship,
+            FlowDirection = FlowDirection.LeftToRight,
+            TextAlignment = TextAlignment.Left,
+        };
+        BidiWpf.Apply(hostManaged);
+        hostManaged.FlowDirection = FlowDirection.LeftToRight;
+        hostManaged.TextAlignment = TextAlignment.Center;
+        BidiWpf.Apply(hostManaged, alignment: BidiAlignment.Preserve);
+        Equal(FlowDirection.RightToLeft, hostManaged.FlowDirection, "managed WPF direction reapplied");
+        Equal(TextAlignment.Center, hostManaged.TextAlignment, "host WPF alignment adopted");
+        hostManaged.Text = "Plain English";
+        BidiWpf.Apply(hostManaged);
+        Equal(FlowDirection.LeftToRight, hostManaged.FlowDirection, "host WPF direction restored");
+        Equal(TextAlignment.Center, hostManaged.TextAlignment, "host WPF alignment restored");
+
+        var boundSource = new BoundProperties();
+        var boundBlock = new TextBlock { Text = flagship };
+        BindingOperations.SetBinding(
+            boundBlock,
+            TextBlock.TextAlignmentProperty,
+            new Binding(nameof(BoundProperties.Alignment)) { Source = boundSource });
+        BindingOperations.SetBinding(
+            boundBlock,
+            FrameworkElement.FlowDirectionProperty,
+            new Binding(nameof(BoundProperties.Direction)) { Source = boundSource });
+        BidiWpf.Apply(boundBlock);
+        True(
+            BindingOperations.IsDataBound(boundBlock, TextBlock.TextAlignmentProperty),
+            "WPF alignment binding preserved while managed");
+        True(
+            BindingOperations.IsDataBound(boundBlock, FrameworkElement.FlowDirectionProperty),
+            "WPF direction binding preserved while managed");
+        BidiWpf.Restore(boundBlock);
+        True(
+            BindingOperations.IsDataBound(boundBlock, TextBlock.TextAlignmentProperty),
+            "WPF alignment binding preserved after restore");
+        True(
+            BindingOperations.IsDataBound(boundBlock, FrameworkElement.FlowDirectionProperty),
+            "WPF direction binding preserved after restore");
+
         var plain = new TextBlock
         {
             Text = "Plain English",
@@ -143,4 +186,10 @@ internal static class Program
         CorpusIsolation[]? ExpectedIsolations);
 
     private sealed record CorpusIsolation(string Text, string Direction, string Kind);
+
+    private sealed class BoundProperties
+    {
+        public TextAlignment Alignment { get; init; } = TextAlignment.Left;
+        public FlowDirection Direction { get; init; } = FlowDirection.LeftToRight;
+    }
 }


### PR DESCRIPTION
## Summary

- track per-property ownership for Android Views, editable UIKit controls, and WPF controls so observable application changes made while BidiLens is active become the new authored state
- distinguish UIKit content-driven direction changes from application ownership changes by reconciling base direction only while the source text is unchanged
- add explicit same-value ownership handoff documentation and `TextView.restoreBidiLens()` for Android; existing UIKit and WPF restore APIs cover the same boundary
- use WPF `SetCurrentValue` for direction/alignment updates so existing dependency-property bindings remain attached during intervention and restoration

## Why

Imperative adapters previously remembered only the first values they saw. If application code changed alignment or paragraph direction during a managed RTL session, a later BidiLens update could restore stale values. This is especially surprising for deliberately left- or center-aligned Persian text. WPF assignments could also replace host bindings.

UIKit exposes base direction through text positions. Replacing the text can change that reported value without an application property handoff, so content changes must not overwrite the authored direction that BidiLens later restores.

Direction and alignment remain independent: developers can keep an RTL paragraph physically left, centered, or right. Pure LTR content in an LTR host remains a state no-op. A same-value assignment is inherently unobservable, so callers must use the documented restore API before that explicit ownership handoff.

## Verification

- `pnpm run check`: 439 tests, 932 corpus cases, Unicode reproducibility, typecheck, lint, docs, builds, and bundled Action probes
- `pnpm run android:check`: all 270 Android library/sample/test/lint/publish tasks plus standalone consumer build
- targeted Android lifecycle tests cover observable host changes and explicit same-value handoff
- hosted Apple tests cover pure-LTR attributed-state preservation, host alignment/direction adoption, and content-change restoration
- hosted Windows tests cover host property adoption and preservation of both WPF bindings
- `git diff --check`

Local Windows has no Swift toolchain or .NET SDK, so the protected macOS Swift and Windows .NET jobs are required before merge.