### PR TITLE
docs: record verified npm 0.3.3 and Android 0.1.2 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ No unreleased changes.
 - Added a derived consistency gate that rejects drift between the Android
   source version, sample, isolated Maven consumer, protected publishing
   workflow, and source-checkout documentation.
-- Prepared the fixed 12-package `0.3.3` set and Android `0.1.2` source candidate
-  without presenting either as registry-public before protected publication and
-  clean registry-only consumer verification succeed.
+- Published all 12 `0.3.3` npm packages and the three signed Android `0.1.2`
+  Maven Central modules from the same protected source commit after the full
+  release gate. Registry integrity, npm provenance, Android signatures,
+  registry-only consumers, and immutable release assets are verified; earlier
+  releases remain available as historical archives.
 
 ## 0.3.2 - 2026-09-01
 

--- a/IMPACT.md
+++ b/IMPACT.md
@@ -2,26 +2,28 @@
 
 ## Measured in this repository
 
+Evidence snapshot: 2026-09-02, web `0.3.3` and Android `0.1.2` release source.
+
 - 12 public JavaScript packages with implementations, declarations, README,
   license, runnable example, and package-local assertion coverage;
 - 932 schema-validated direction fixtures with numbered logical words;
 - 0 fixtures currently certified by a native-language reviewer;
 - property-based stream/source/range checks;
-- 437 unit/property/action tests with 92.22% statements, 86.26% branches,
-  94.85% functions, and 95.02% lines overall (96.28% core lines), including
+- 439 unit/property/action tests with 92.25% statements, 86.28% branches,
+  94.86% functions, and 95.05% lines overall (96.32% core lines), including
   paragraph-boundary security, isolate balancing, and non-finite-option
   regressions;
 - 30 Playwright browser/visual tests spanning Chromium, Firefox, and WebKit, including
   structured Markdown, real Chromium clipboard verification, and no-build
   standalone Web Component loading, plus the full offline bilingual playground
   controls, corpus, copy invariant, theme, and export flow;
-- a self-contained 199,943-byte Node 24 GitHub Action bundle with source tests
+- a self-contained 185,234-byte Node 24 GitHub Action bundle with source tests
   and built-artifact safe/strict-failure probes;
 - reproducible Unicode 17.0.0 source and generated tables;
 - clean tarball installation, strict consumer type-check, runtime imports, and
   execution of the exact examples extracted from all 12 tarballs;
 - no known dependency vulnerabilities at the recorded audit;
-- a validated CycloneDX 1.7 SBOM with 577 components and 591 dependency
+- a validated CycloneDX 1.7 SBOM with 523 components and 537 dependency
   relationships;
 - all 12 tarballs installed and exercised in a strict isolated consumer.
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -13,21 +13,17 @@
 [مشارکت](CONTRIBUTING.md) · [وضعیت پروژه](docs/V1_BUILD_REPORT.md)
 
 > [!IMPORTANT]
-> نسخهٔ `0.3.2` بخش وب و JavaScript برای هر ۱۲ بستهٔ `@bidilens/*` در npm
+> نسخهٔ `0.3.3` بخش وب و JavaScript برای هر ۱۲ بستهٔ `@bidilens/*` در npm
 > عمومی است و یکپارچگی رجیستری و SLSA provenance آن‌ها تأیید شده است؛ tarballها،
 > manifest و SBOM دقیق آن در
-> [انتشار تغییرناپذیر `v0.3.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2)
+> [انتشار تغییرناپذیر `v0.3.3`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3)
 > نگه‌داری می‌شود. این نسخه پس از عبور از گیت کامل انتشار، از commit محافظت‌شدهٔ
-> `97f4827a9683c343a92f4ff31f4fa1fc0a718e99` منتشر شده است. نسخهٔ تاریخی `0.3.1`
-> نیز به‌صورت انتشار تغییرناپذیر در دسترس است. نسخهٔ `0.1.1` هستهٔ Kotlin و ماژول‌های Android Views و
-> Jetpack Compose نیز امضاشده و در Maven Central عمومی است؛ برنامهٔ نمونه و
-> شواهد انتشار در
-> [`android-v0.1.1`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1)
-> قرار دارند.
-> نامزدهای بررسی‌شدهٔ موجود در کد منبع، نسخهٔ `0.3.3` وب/بسته‌ها و نسخهٔ
-> `0.1.2` Android هستند. تا وقتی workflow محافظت‌شدهٔ انتشار و آزمون مصرف‌کنندهٔ
-> تمیز فقط از رجیستری با موفقیت تمام نشده‌اند، این دو نسخه عمومی محسوب نمی‌شوند؛
-> بنابراین مثال‌های نصب همچنان نسخه‌های عمومی و تأییدشدهٔ بالا را نشان می‌دهند.
+> `51dcd971efa5873a393b90cb6311c73f4315b8e8` منتشر شده است. نسخهٔ `0.1.2`
+> هستهٔ Kotlin و ماژول‌های Android Views و Jetpack Compose نیز از همین commit،
+> امضاشده و در Maven Central عمومی است؛ فایل‌های AAR، برنامهٔ نمونه، شواهد
+> امضا و checksum و نتیجهٔ آزمون مصرف‌کنندهٔ تمیز از رجیستری عمومی در
+> [انتشار تغییرناپذیر `android-v0.1.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
+> ثبت شده‌اند. نسخه‌های پیشین نیز به‌صورت آرشیو تغییرناپذیر در دسترس هستند.
 
 BidiLens یک ابزار متن‌باز و آفلاین برای نمایش درست متن‌های ترکیبی راست‌به‌چپ
 و چپ‌به‌راست در رابط‌های هوش مصنوعی، Markdown، برنامه‌های وب و Android است.
@@ -89,13 +85,13 @@ The Persian word کتاب means “book”.
 - بستهٔ Swift با نمای خواندنی `BidiText` برای SwiftUI و اتصال‌های UIKit،
   جداسازی جهت پاراگراف از ترازبندی فیزیکی و آزمون‌های شبیه‌ساز iOS.
 
-راهنمای نصب از source، تنظیم `android:supportsRtl="true"` و نمونه‌کدهای
+راهنمای نصب از Maven Central یا source، تنظیم `android:supportsRtl="true"` و نمونه‌کدهای
 Compose و Views در [راهنمای Android](android/README.md) قرار دارد.
 
 تمام بسته‌های عمومی ESM-only هستند و برای استفادهٔ سمت سرور به Node.js 22.12 یا
-جدیدتر نیاز دارند. مجموعهٔ کامل `0.3.2` در
+جدیدتر نیاز دارند. مجموعهٔ کامل `0.3.3` در
 [سازمان `@bidilens` در npm](https://www.npmjs.com/org/bidilens) منتشر شده است؛
-مجموعهٔ `0.3.1` نیز به‌عنوان نسخهٔ تاریخی تغییرناپذیر باقی مانده است.
+مجموعه‌های `0.3.2` و `0.3.1` نیز به‌عنوان نسخه‌های تاریخی تغییرناپذیر باقی مانده‌اند.
 
 پروژه با [مجوز MIT](LICENSE) متن‌باز است. شرایط داده‌های Unicode و بخش
 Apache-2.0 پیکره در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) حفظ شده
@@ -109,7 +105,7 @@ Apache-2.0 پیکره در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) حف
 استفاده است:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.2"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.3"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 
@@ -148,7 +144,7 @@ pnpm run android:check
 ## محدودیت‌های صریح
 
 نسخهٔ فعلی بسته‌های وب و TypeScript و پیاده‌سازی بومی Android را دارد.
-نسخهٔ `0.1.1` Android به‌صورت امضاشده در Maven Central منتشر شده و روی
+نسخهٔ `0.1.2` Android به‌صورت امضاشده در Maven Central منتشر شده و روی
 شبیه‌ساز آزموده شده است؛ آزمون دستگاه‌های فیزیکی OEM، صفحه‌کلیدهای مختلف،
 TalkBack و پایلوت محصول واقعی هنوز باقی مانده‌اند.
 Flutter، React Native، SwiftUI ویرایشی، Electron، افزونهٔ VS Code، PDF و آزمون

--- a/README.md
+++ b/README.md
@@ -19,22 +19,18 @@
 [Project status](docs/V1_BUILD_REPORT.md)
 
 > [!IMPORTANT]
-> The JavaScript/web `0.3.2` release is public across all 12 `@bidilens/*`
+> The JavaScript/web `0.3.3` release is public across all 12 `@bidilens/*`
 > packages with verified registry integrity and SLSA provenance; its exact
 > tarballs, manifest, and SBOM are retained in the immutable
-> [`v0.3.2` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2).
+> [`v0.3.3` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3).
 > It was published from protected `main` commit
-> `97f4827a9683c343a92f4ff31f4fa1fc0a718e99` after the complete release gate.
-> The prior `0.3.1` release remains available as an immutable historical
-> release. Native Android core, Views, and
-> Compose `0.1.1` artifacts
-> are signed and public on Maven Central, with a verified sample and evidence
-> bundle in the
-> [`android-v0.1.1` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1).
-> The reviewed source candidates are web/package `0.3.3` and Android `0.1.2`.
-> They are not public registry releases until their protected publication
-> workflows and clean registry-only consumer checks succeed; install examples
-> therefore continue to use the verified public versions above.
+> `51dcd971efa5873a393b90cb6311c73f4315b8e8` after the complete release gate.
+> Native Android core, Views, and Compose `0.1.2` artifacts from the same
+> commit are signed and public on Maven Central. Their AARs, sample APK,
+> public signature/checksum evidence, and clean public-consumer verification
+> are recorded in the immutable
+> [`android-v0.1.2` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2).
+> Previous releases remain available as immutable historical archives.
 > Native Swift/UIKit/SwiftUI, .NET/WPF, and Rust core implementations are
 > present in source with dedicated CI gates, but are not yet registry-published
 > or validated in a downstream production/accessibility lab. Other
@@ -178,9 +174,9 @@ reordering and shaping; BidiLens supplies the application structure they need.
 
 All public packages are ESM-only, require maintained Node.js 22.12 or newer for
 server-side use, include declarations, a package README, license, and runnable example.
-Browser packages target current standards-based browsers. The complete `0.3.2`
+Browser packages target current standards-based browsers. The complete `0.3.3`
 package set is [published under the `@bidilens` npm scope](https://www.npmjs.com/org/bidilens);
-the prior `0.3.1` set remains available as a reproducible historical release.
+the prior `0.3.2` and `0.3.1` sets remain available as historical releases.
 
 ## Consumer install
 
@@ -202,7 +198,7 @@ For a no-build browser page, the published Web Component also exposes a
 standalone entry that bundles the core and needs no import map:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.2"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.3"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 
@@ -328,7 +324,7 @@ for security-sensitive findings.
 
 The implemented web/JavaScript packages are public-beta quality, not a
 guarantee about every proprietary renderer. Native Android is implemented,
-emulator-tested, and published as signed Maven Central `0.1.1` artifacts, but
+emulator-tested, and published as signed Maven Central `0.1.2` artifacts, but
 physical OEM/IME/TalkBack validation and an external production pilot remain
 open. Flutter, React Native, editable SwiftUI, Electron, VS Code, PDF, screen-reader
 laboratory validation, crates.io publication, and downstream product patches

--- a/android/README.md
+++ b/android/README.md
@@ -34,7 +34,7 @@ Android Gradle Plugin 9.3.2, compile SDK 36, and Kotlin 2.4.10.
 
 ## Use with Jetpack Compose
 
-Version `0.1.1` is signed and public on Maven Central. Normal Gradle setup is:
+Version `0.1.2` is signed and public on Maven Central. Normal Gradle setup is:
 
 ```kotlin
 dependencyResolutionManagement {
@@ -45,28 +45,29 @@ dependencyResolutionManagement {
 }
 
 dependencies {
-    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.1")
+    implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.2")
 }
 ```
 
 The other coordinates are
-`io.github.codeinscrubs.bidilens:bidilens-core:0.1.1` and
-`io.github.codeinscrubs.bidilens:bidilens-android-views:0.1.1`. Choose the
+`io.github.codeinscrubs.bidilens:bidilens-core:0.1.2` and
+`io.github.codeinscrubs.bidilens:bidilens-android-views:0.1.2`. Choose the
 surface used by the application; adapter dependencies bring in the core
 transitively.
 
 For source-checkout development, publish the current modules to Maven Local:
 
-Source checkout version `0.1.2` is a reviewed release candidate containing the
-latest combining-mark parity and host-property ownership fixes. It is not a
-public Maven Central version until the protected publication workflow and a
-clean public-only consumer both succeed.
+Source checkout version `0.1.2` matches the published release containing the
+combining-mark parity and host-property ownership fixes. Maven Local is only
+needed when testing your own source changes; normal consumers should use
+Maven Central without a local publication step.
 
 ```bash
 ./android/gradlew -p android publishToMavenLocal
 ```
 
-Then add:
+For local development only, add `mavenLocal()` to the consumer's repositories
+before Maven Central, then use the same coordinate:
 
 ```kotlin
 dependencies {
@@ -187,7 +188,7 @@ pnpm run android:check
 Current executable evidence includes:
 
 - all 932 canonical direction fixtures and declared isolation plans in Kotlin;
-- 29 core, 11 Views/Robolectric, and 9 Compose JVM tests;
+- 31 core, 13 Views/Robolectric, and 9 Compose JVM tests;
 - 3 Views and 3 Compose UI tests on an Android 16/API 36.1 emulator;
 - release AAR assembly, sample APK assembly, and Android lint;
 - an isolated consumer build against the generated Maven-local coordinates;
@@ -195,19 +196,26 @@ Current executable evidence includes:
 
 ## Distribution status
 
-Version `0.1.1` is publicly available from Maven Central as three signed
+Version `0.1.2` is publicly available from Maven Central as three signed
 modules. After publication, all 15 primary artifacts were downloaded and
 matched byte-for-byte against the protected workflow outputs; all detached
 signatures and published checksums verified; and a clean Gradle consumer with
 an empty Maven Local resolved all three coordinates and built successfully.
 The immutable
-[`android-v0.1.1` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1)
+[`android-v0.1.2` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
 retains the individual AARs, sample APK, Maven repository, public Central
-evidence, public signing key, and SHA-256 checksums. The older
+evidence, public signing key, and SHA-256 checksums. The `0.1.1` release remains
+the immutable first-Central archive. The older
 [`android-v0.1.0` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.0)
 remains available only as the immutable pre-Central archive. Source checkout
 and `publishToMavenLocal` remain supported. The npm packages are a separate
 JavaScript/web distribution.
+
+The sample APK is a debug/demo build, not a production application. The Maven
+documentation jars are minimal publication-compatibility artifacts, not a
+complete generated API reference; use this guide and the version-tagged source.
+Physical OEM-device, IME, TalkBack, and downstream production validation remain
+separate rollout requirements.
 
 See the repository [limitations](../docs/LIMITATIONS.md), [architecture](../docs/ARCHITECTURE.md),
 and [security policy](../SECURITY.md) before production rollout.

--- a/android/README.md
+++ b/android/README.md
@@ -34,7 +34,9 @@ Android Gradle Plugin 9.3.2, compile SDK 36, and Kotlin 2.4.10.
 
 ## Use with Jetpack Compose
 
-Version `0.1.2` is signed and public on Maven Central. Normal Gradle setup is:
+Version `0.1.2` is signed and public on Maven Central. In the application's
+`settings.gradle.kts`, add any missing repositories without replacing existing
+repository configuration:
 
 ```kotlin
 dependencyResolutionManagement {
@@ -43,7 +45,11 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
+```
 
+In the app module's `build.gradle.kts`, add the dependency:
+
+```kotlin
 dependencies {
     implementation("io.github.codeinscrubs.bidilens:bidilens-android-compose:0.1.2")
 }
@@ -66,8 +72,9 @@ Maven Central without a local publication step.
 ./android/gradlew -p android publishToMavenLocal
 ```
 
-For local development only, add `mavenLocal()` to the consumer's repositories
-before Maven Central, then use the same coordinate:
+For local development only, add `mavenLocal()` to the repositories inside
+`dependencyResolutionManagement` in the consumer's `settings.gradle.kts`,
+before Maven Central. Use the same coordinate in its app module:
 
 ```kotlin
 dependencies {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -82,9 +82,9 @@ acceptance invariants are collected in the
 
 ## Where are Android, Apple, Windows, Rust, Flutter, React Native, VS Code, Electron, and PDF?
 
-Android core, Views, and Compose `0.1.1` are signed and public on Maven Central;
+Android core, Views, and Compose `0.1.2` are signed and public on Maven Central;
 the sample and verification evidence are in the
-[`android-v0.1.1` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1).
+[`android-v0.1.2` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2).
 Physical OEM/IME/TalkBack and external product validation remain open; see the
 [Android guide](../android/README.md). A source Swift Package with a SwiftUI
 `BidiText` renderer and UIKit adapters, plus a .NET 8/WPF implementation, now live in the

--- a/docs/OUTREACH.md
+++ b/docs/OUTREACH.md
@@ -1,6 +1,6 @@
 # Maintainer outreach kit
 
-BidiLens web `0.3.2` and signed Android `0.1.1` are published for source review
+BidiLens web `0.3.3` and signed Android `0.1.2` are published for source review
 and bounded pilots. Android has emulator and public-consumer evidence;
 physical-device/OEM/IME/TalkBack and production validation remain pending.
 Neither availability is evidence of adoption. Contact maintainers with one
@@ -46,8 +46,8 @@ Thank you,
 
 - Problem and quick start: [README](../README.md)
 - Published packages: [`@bidilens` on npm](https://www.npmjs.com/org/bidilens)
-- Versioned web release: [`v0.3.2` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2)
-- Versioned Android release: [`android-v0.1.1` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1)
+- Versioned web release: [`v0.3.3` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3)
+- Versioned Android release: [`android-v0.1.2` on GitHub](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
 - Native Android integration: [Android guide](../android/README.md)
 - Apple integration: [SwiftUI/UIKit guide](../apple/README.md)
 - Windows integration: [.NET/WPF guide](../windows/README.md)
@@ -69,8 +69,8 @@ pnpm run test:visual
 pnpm run release:check
 ```
 
-For an initial web review, install `@bidilens/core@0.3.2`; for Android, use one
-exact `io.github.codeinscrubs.bidilens:*:0.1.1` coordinate. Ask for confirmation
+For an initial web review, install `@bidilens/core@0.3.3`; for Android, use one
+exact `io.github.codeinscrubs.bidilens:*:0.1.2` coordinate. Ask for confirmation
 of the host bug, feedback on the API boundary, or permission to prepare a small
 draft pull request. Do not claim universal rendering, zero defects,
 native-platform coverage beyond the documented Android, SwiftUI/UIKit, and WPF

--- a/docs/OUTREACH_LOG.md
+++ b/docs/OUTREACH_LOG.md
@@ -4,6 +4,8 @@
 
 **Last response audit:** 2026-09-01
 
+**Last code-PR and publication audit:** 2026-09-02 (no mailbox refresh)
+
 This log records public requests for review and bounded organizational
 role-address outreach. Public routes are independently link-verifiable; email
 sends are verifiable only in the sender's mailbox. Neither kind of submission
@@ -39,7 +41,7 @@ endorsement.
 | OpenAI Codex CLI | [comment on issue #34871](https://github.com/openai/codex/issues/34871#issuecomment-5088082730) | Parent issue open | Separates bidi ordering from Arabic shaping and terminal capabilities. It offers the policy/corpus for a native Rust design rather than proposing a JavaScript dependency. |
 | OpenAI Codex community | [Show and tell #35557](https://github.com/openai/codex/discussions/35557) | Open | Public technical introduction, package/corpus summary, current integration evidence, limitations, and request for renderer/i18n review. |
 | Cline | [comment on feature discussion #12089](https://github.com/cline/cline/discussions/12089#discussioncomment-17793649) | Discussion open | Links the open renderer regression, supplies the mixed-content acceptance case, and offers a React/webview pilot or fixtures-only patch. |
-| Cline VS Code webview | [PR #12724](https://github.com/cline/cline/pull/12724) | Open but currently conflicting/dirty; hosted checks on the current head pass, and maintainer review is still required | Applies `@bidilens/markdown` at the existing React Markdown render boundary and adds Persian-majority, English-majority, and pure-English identity tests. Quality, unit, platform-integration, VS Code on Ubuntu/Windows, E2E on Ubuntu/macOS/Windows, and both Socket security checks passed; the branch needs an upstream conflict-resolution update before it can merge. |
+| Cline VS Code webview | [PR #12724](https://github.com/cline/cline/pull/12724) | Open and mergeable on 2026-09-02; protected merge is blocked and maintainer review is required | Applies `@bidilens/markdown` at the existing React Markdown render boundary and adds Persian-majority, English-majority, and pure-English identity tests. Current head `62d84984e5cd281797ee6943f4b819e4ca069ed2` exposes two successful Socket checks and one skipped badge-stripping check; the earlier full host-test result is not a current-head CI claim. Maintainer review and host CI approval remain external gates. |
 | Continue | [comment on issue #2767](https://github.com/continuedev/continue/issues/2767#issuecomment-5088124777) | Parent issue closed; reconsideration requested | Replaces the proposed global RTL rule with Auto/LTR/RTL policy and offers a focused GUI or fixtures-only patch. No new duplicate issue was created. |
 | assistant-ui | [Show and tell #5211](https://github.com/assistant-ui/assistant-ui/discussions/5211) | Open | Distinguishes the project's completed logical-layout work from per-message mixed-content direction and offers a documented `@bidilens/react` streaming recipe, adapter, hook, or fixtures-only path. |
 | AnythingLLM | [comment on canonical RTL issue #3430](https://github.com/Mintplex-Labs/anything-llm/issues/3430#issuecomment-5126056699) | Parent issue open | Supplies a per-block acceptance fixture and integration guidance. [BidiLens PR #57](https://github.com/CodeinScrubs/BidiLens/pull/57) addresses the Markdown-It 13/14/15 peer/type gap with packed cross-version evidence, but AnythingLLM's Node 18 floor still conflicts with BidiLens 0.3's Node 22.12 minimum; a native fixtures-only patch remains the non-regressive route unless that runtime boundary changes. |
@@ -236,6 +238,39 @@ a CycloneDX 1.7 SBOM; GitHub asset digests match the retained files.
 
 This update records release evidence only. External outreach threads were not
 changed, and no adoption, endorsement, or universal-rendering claim is made.
+
+### 0.3.3 and Android 0.1.2 completion update (2026-09-02)
+
+The release preparation in [PR #79](https://github.com/CodeinScrubs/BidiLens/pull/79)
+passed all 24 required CI/CodeQL contexts and merged as
+`51dcd971efa5873a393b90cb6311c73f4315b8e8`. Protected npm run
+[`33591632030`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33591632030)
+published all 12 `0.3.3` packages; protected Android run
+[`33610612564`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33610612564)
+published all three signed `0.1.2` modules to Central. Independent public
+consumers, retained/public artifact equality, npm provenance/signatures, and
+Android signatures/checksums verified. Immutable releases
+[`v0.3.3`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3) and
+[`android-v0.1.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
+retain the exact artifacts and evidence.
+
+A separate live code-PR check found:
+
+- Hermes #72508 is open and mergeable at
+  `09c51fdd59d8d64a4fa901ac437200bcfc15bd54`; GitHub reports protected merge
+  blocked, and no human approval is recorded.
+- Cline #12724 is open, mergeable, and review-required at
+  `62d84984e5cd281797ee6943f4b819e4ca069ed2`. Two Socket checks passed; the
+  full host CI matrix is not evidenced on this head. Older conflicting/head
+  status in the dated snapshots above remains historical, not current.
+- Streamdown #569 remains merged at
+  `7e824007a37d26f356f9fbb37d65db8e4cd12680` on 2026-08-14. This was a native
+  implementation, not adoption of a BidiLens package dependency.
+
+No mailbox, other issue/discussion route, or new maintainer response was audited
+in this publication pass. No external outreach thread was edited or bumped,
+and no email or reminder was sent. Publication does not imply product adoption,
+company endorsement, or universal rendering correctness.
 
 ## Deliberate deferrals
 

--- a/docs/OUTREACH_LOG.md
+++ b/docs/OUTREACH_LOG.md
@@ -2,9 +2,9 @@
 
 **Initial outreach evidence date:** 2026-07-30
 
-**Last response audit:** 2026-09-01
+**Last response audit:** 2026-09-02 (focused project-mail search)
 
-**Last code-PR and publication audit:** 2026-09-02 (no mailbox refresh)
+**Last code-PR and publication audit:** 2026-09-02
 
 This log records public requests for review and bounded organizational
 role-address outreach. Public routes are independently link-verifiable; email
@@ -267,10 +267,15 @@ A separate live code-PR check found:
   `7e824007a37d26f356f9fbb37d65db8e4cd12680` on 2026-08-14. This was a native
   implementation, not adoption of a BidiLens package dependency.
 
-No mailbox, other issue/discussion route, or new maintainer response was audited
-in this publication pass. No external outreach thread was edited or bumped,
-and no email or reminder was sent. Publication does not imply product adoption,
-company endorsement, or universal rendering correctness.
+The publication check did not refresh other issue/discussion routes. A later
+focused mailbox search on the same day used
+`in:anywhere after:2026/08/31 {BidiLens bidirectional "mixed-direction" RTL LTR "T-1645"} -from:me`.
+Its 36 matching messages were npm publication notices for the `0.3.1`, `0.3.2`,
+and `0.3.3` package sets; no new maintainer reply requiring an answer was found
+within that search. Existing drafts and account settings were left unchanged.
+No external outreach thread was edited or bumped, and no email or reminder was
+sent. Publication does not imply product adoption, company endorsement, or
+universal rendering correctness.
 
 ## Deliberate deferrals
 

--- a/docs/PROJECT_COMPARISON.md
+++ b/docs/PROJECT_COMPARISON.md
@@ -186,7 +186,8 @@ lockfile install:
   pin in the security self-scan job prevents that job from reaching its scan;
 - the declared GitHub repository does not exist and npm returns `E404` for
   both `@bidiguard/core` and `@bidiguard/react-native`. Canonical BidiLens is
-  public and its 12 packages resolve at version `0.3.2`.
+  public; its current verified 12-package release is `0.3.3` (2026-09-02).
+  This publication update does not redate the sibling-source audit above.
 
 Passing tests also miss release- and behavior-critical defects reproduced
 against the built sibling artifacts:

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -2,31 +2,51 @@
 
 The canonical source is published at
 [`CodeinScrubs/BidiLens`](https://github.com/CodeinScrubs/BidiLens). This
-checklist records the completed web/npm `0.3.2` (with `0.3.1` retained as a
-historical release) and Android/Maven `0.1.1`
-releases, the reviewed `0.3.3`/Android `0.1.2` source candidates, and the
-controls required for future releases.
+checklist records the completed web/npm `0.3.3` and Android/Maven `0.1.2`
+releases, preserves earlier publication evidence, and defines the controls
+required for future releases.
 
-## Pending release candidates
+## Current verified releases — 2026-09-02
 
-The current tree declares web/package `0.3.3` and Android `0.1.2`. These are
-reviewed source candidates, not registry-public release claims. Web `0.3.3`
-adds cross-platform combining-mark isolation parity; Android `0.1.2` also
-includes observable host-property ownership fixes for native adapters.
+Web/package `0.3.3` and Android `0.1.2` are public from protected `main` commit
+`51dcd971efa5873a393b90cb6311c73f4315b8e8`. The release preparation in
+[PR #79](https://github.com/CodeinScrubs/BidiLens/pull/79) passed all 19
+[CI jobs](https://github.com/CodeinScrubs/BidiLens/actions/runs/33589740575)
+and five [CodeQL analyses](https://github.com/CodeinScrubs/BidiLens/actions/runs/33589740613).
+The reviewed head and merged commit have the identical Git tree
+`1d2d406d5eacf6521f851131e75af4e75793e736`.
 
-Neither candidate becomes public merely by merging this version preparation.
-The exact merged `main` commit must pass every protected check, the appropriate
-protected publication workflow, registry integrity/provenance or signature
-verification, and a clean registry-only consumer. Only after those gates may
-the README install examples, latest-public statements, tags, and immutable
-GitHub releases move to `0.3.3` or `android-v0.1.2`.
+- Protected npm run
+  [`33591632030`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33591632030)
+  published all 12 `0.3.3` packages through OIDC. Independent checks matched
+  every retained tarball's SHA-256 and registry SHA-512, `latest` tag, SLSA
+  provenance, and registry signature. A separate registry-only consumer
+  passed strict TypeScript, adapter/runtime/source-preservation, pure-LTR
+  no-op, streaming, and installed-CLI checks. `npm audit signatures` verified
+  114 signatures and 53 attestations across that consumer's dependency tree.
+- Protected Android run
+  [`33610612564`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33610612564)
+  published Central deployment `cb7febfc-1313-4b3c-8171-d8a473cb92da`. All 15
+  primary files match retained workflow bytes; 15 OpenPGP signatures and 30
+  public checksums verify. A clean public-only consumer with an empty Maven
+  Local resolved all three `0.1.2` modules and built successfully.
+- Annotated tags and immutable releases
+  [`v0.3.3`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3) and
+  [`android-v0.1.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
+  identify that exact source commit and retain the release artifacts and
+  verification evidence. GitHub asset SHA-256 digests match the local files.
+
+Merging a version preparation alone never proves publication. Future releases
+must repeat protected checks, publication, registry integrity/provenance or
+signature verification, and a clean registry-only consumer before install
+examples and latest-public statements move forward.
 
 ## Android distribution boundary
 
-The three Android `0.1.1` libraries under `android/` are signed and public on
+The three Android `0.1.2` libraries under `android/` are signed and public on
 Maven Central. They can also be verified locally with
 `./android/gradlew -p android publishToMavenLocal`. The
-[`android-v0.1.1` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1)
+[`android-v0.1.2` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
 retains the exact release assets and public verification evidence. The verified
 [`android-v0.1.0` GitHub release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.0)
 remains the immutable pre-Central fallback tied to commit `85b80c0`.
@@ -44,7 +64,9 @@ a clean consumer against an isolated Maven repository; retains SHA-256
 evidence; and only then uploads. The libraries must not be described as
 publicly available from Maven Central until Central accepts the deployment and
 a clean consumer resolves it from the public repository. Android `0.1.1`
-completed both gates on 2026-07-28.
+first completed both gates on 2026-07-28; `0.1.2` repeated them on 2026-09-02.
+The documentation jars are minimal compatibility artifacts, not a complete
+generated API reference. The sample APK is a debug/demo build.
 
 ### Android release workflow
 
@@ -55,7 +77,7 @@ Central, and has read-only repository permissions. Registry credentials and
 the private signing key are exposed only to the specific steps that require
 them.
 
-Android `0.1.1` completed this workflow:
+The first Central release, Android `0.1.1`, completed this workflow:
 
 1. all 13 protected CI checks passed in
    [`30337482079`](https://github.com/CodeinScrubs/BidiLens/actions/runs/30337482079);
@@ -72,9 +94,14 @@ Android `0.1.1` completed this workflow:
    published commit `c59a5b674482081980fc886f6d38036f88af5dc8`, retaining the
    Maven inputs, sample APK, public evidence, signing key, and checksums.
 
+Android `0.1.2` repeated that workflow on the exact source commit, protected run,
+and Central deployment recorded in the current-release section above. Its
+immutable archive preserves all 33 staged repository files, including metadata,
+and the independently downloaded public artifacts and verification report.
+
 Maven Central versions are immutable. A failed or partially visible release is
-never repaired by replacing `0.1.1`; the next corrected source must use a new
-version.
+never repaired by replacing an existing version; corrected source must use a
+new version.
 
 ## Completed repository prerequisites
 
@@ -95,17 +122,17 @@ version.
 - MIT project license plus Unicode and imported-corpus notices;
 - human-controlled release preparation and protected npm publication
   workflows;
-- all 12 `@bidilens/*@0.3.2` packages published publicly with SLSA provenance;
+- all 12 `@bidilens/*@0.3.3` packages published publicly with SLSA provenance;
 - retained release tarballs whose SHA-512 values match the public registry;
 - per-package GitHub OIDC trusted publishers bound to `publish.yml` and the
   protected `npm-release` environment;
 - token-based publishing disabled through npm's recommended
   `Require two-factor authentication and disallow tokens` package setting;
-- annotated `v0.3.2` tag and immutable GitHub release for the exact published
+- annotated `v0.3.3` tag and immutable GitHub release for the exact published
   source commit, with all package tarballs, release manifest, and SBOM attached;
-- signed Android `0.1.1` artifacts published under the verified
+- signed Android `0.1.2` artifacts published under the verified
   `io.github.codeinscrubs.bidilens` namespace, with protected release evidence,
-  public-only consumer verification, annotated `android-v0.1.1` tag, and
+  public-only consumer verification, annotated `android-v0.1.2` tag, and
   immutable GitHub release.
 
 ## Remaining external adoption prerequisites
@@ -119,7 +146,7 @@ On 2026-09-01, protected publication run
 [`33508856274`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33508856274)
 published all 12 version `0.3.2` packages from exact commit
 `97f4827a9683c343a92f4ff31f4fa1fc0a718e99` through GitHub OIDC trusted
-publishing. Every package resolved as `latest@0.3.2` with matching registry
+publishing. Every package then resolved as `latest@0.3.2` with matching registry
 SHA-512 integrity and SLSA provenance. The retained tarball SHA-256 values
 matched the publication manifest, and the annotated
 [`v0.3.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2) tag

--- a/docs/REQUIREMENT_MATRIX.md
+++ b/docs/REQUIREMENT_MATRIX.md
@@ -1,6 +1,6 @@
 # Build-specification traceability matrix
 
-**Current-tree evidence date:** 2026-09-01
+**Current-tree evidence date:** 2026-09-02
 
 This file maps the binding “Ultimate Build Instruction — Cross-Platform
 Bidirectional Text Toolkit for AI Interfaces, version 2.0” to the source and
@@ -28,7 +28,7 @@ Status vocabulary:
 | LTR-only non-interference | Complete and tested for shipped web surfaces | In the default `auto` mode, ordinary LTR content in an LTR context emits no BidiLens direction attributes, wrappers, inline styles, or controls. Exact-output/tree/DOM tests cover core, HTML, DOM, Markdown, React, Vue, Svelte, Web Component, terminal, CLI, and Playwright helpers; inherited RTL and hidden-control counterexamples prevent an unsafe fast-path bypass |
 | Every public package has implementation, ≥25 package-local assertions, README/install, and example | Complete and executable | `pnpm run packages:depth` enforces this for all 12 packages; packed examples are also exercised by `pnpm run release:check` |
 | Full source lives in Git; annotated milestone tag after every gate | Partial | Reviewed source is committed to the canonical public Git repository, but only historical tags `m0` and `m1` exist. Missing history is not retroactively fabricated |
-| No fabricated badges, counts, adoption, or publication | Complete for the current tree | Publication is tied to registry/release evidence; the [outreach log](OUTREACH_LOG.md) labels submissions as contact only and makes no merge, audit, pilot, adoption, endorsement, or unverified badge claim |
+| No fabricated badges, counts, adoption, or publication | Complete for the current tree | Publication is tied to registry/release evidence; the [outreach log](OUTREACH_LOG.md) distinguishes submitted proposals from the verified Streamdown native-patch merge. Neither is presented as an audit, pilot, BidiLens dependency adoption, or company endorsement |
 | ≥300 corpus fixtures | Complete as a technical corpus; external review incomplete | 932 schema-valid entries; 735 authored template-matrix cases, 196 attributed sibling-project seeds, one user fixture; zero are marked native-speaker-reviewed |
 | Automated wrong-versus-correct visual proof | Complete and tested | `tests/visual/flagship.spec.ts` and committed Windows/Arial baselines; Chromium, Firefox, and WebKit gate |
 
@@ -71,7 +71,7 @@ batch plugin path; it is not misrepresented as a stateful streaming backend.
 
 | Surface | Status | Evidence or exact gap |
 |---|---|---|
-| Android/Jetpack Compose | Implemented; `0.1.1` published and `0.1.2` in source review; external validation pending | Maven Central `0.1.1` pure Kotlin core, Views, and Compose libraries; source candidate `0.1.2` adds combining-mark parity and host-property ownership fixes; sample app; generated 932-case corpus; JVM/Robolectric suites; lint/AAR/APK tasks; isolated Maven-local consumer; 3 Views plus 3 Compose UI tests on local API 36.1; and an API 35 emulator CI gate. Physical-device/OEM/IME/TalkBack evidence and a downstream pilot remain open |
+| Android/Jetpack Compose | Implemented; `0.1.2` published; external validation pending | Signed Maven Central pure Kotlin core, Views, and Compose libraries with combining-mark parity and host-property ownership fixes; sample app; generated 932-case corpus; JVM/Robolectric suites; lint/AAR/APK tasks; isolated Maven-local and public-only consumers; 3 Views plus 3 Compose UI tests on local API 36.1; and an API 35 emulator CI gate. Physical-device/OEM/IME/TalkBack evidence and a downstream pilot remain open |
 | Flutter/Dart | Missing | No package/demo, generated corpus representation, widget/golden tests, or SDK build report |
 | React Native | Missing | No component, generated corpus representation, native tests, or platform build report |
 | Swift Package/SwiftUI/UIKit | Source and hosted simulator/compiler validation complete; physical-device/release validation pending | Swift Package, generated Unicode 17 ranges, copied 932-case corpus, core tests/example, UIKit `UILabel`/`UITextView`/`UITextField` adapters, UIKit-backed SwiftUI `BidiText`, independent physical alignment, and protected macOS/iOS Simulator gates in [CI](https://github.com/CodeinScrubs/BidiLens/actions/workflows/ci.yml). Physical iOS/VoiceOver evidence, sample app, editable SwiftUI integration, and registry publication remain open |
@@ -136,7 +136,7 @@ recorded explicitly.
 | CI: VS Code and native builds | Partial | Android unit/lint/AAR/APK and API 35 device jobs are pinned and executable; signed Android publication has an isolated-consumer gate; Apple Swift/macOS/iOS Simulator, Windows .NET/WPF, and native Rust three-OS jobs have hosted compiler/test evidence. VS Code and unimplemented native-platform adapters remain open |
 | Changesets and human-controlled release workflow | Complete | Changesets configuration, opt-in web release preparation, protected manual npm publication with exact confirmation and provenance, and protected manual Maven Central publication with signing and version-reuse rejection |
 | Clean packed consumer | Complete and tested | `pnpm run release:check` passes from the reviewed clean commit: all 12 packages build, pack, inspect, install into a strict consumer, import at runtime, and execute their exact packed examples |
-| Registry ownership, provenance, public repo metadata, credentials | Complete for the published package set | Canonical GitHub metadata, `@bidilens` ownership, and `io.github.codeinscrubs` namespace verified; all 12 npm `0.3.2` packages are public with SLSA provenance and matching integrity; all three Android `0.1.1` modules are signed and public with matching Central artifacts, signatures, and checksums; release credentials are protected outside the repository |
+| Registry ownership, provenance, public repo metadata, credentials | Complete for the published package set | Canonical GitHub metadata, `@bidilens` ownership, and `io.github.codeinscrubs` namespace verified; all 12 npm `0.3.3` packages are public with SLSA provenance and matching integrity; all three Android `0.1.2` modules are signed and public with matching Central artifacts, signatures, and checksums; release credentials are protected outside the repository |
 | Name/trademark decision | Partial/external | ADR records provisional `BidiLens`; final registry/legal review is still required |
 
 ## Milestone gate status
@@ -155,7 +155,7 @@ tag. Therefore working code alone cannot make an historical milestone green.
 | M6 ≥300/visual/copy | Implemented; historical gate incomplete | 932 corpus cases and 30 three-engine visual tests pass; no `m6` tag |
 | M7 native + terminal | Partial | Terminal, Android, SwiftUI/UIKit, and .NET/WPF exist; Flutter, React Native, and other documented native adapters remain open; no `m7` tag |
 | M8 playground/full EN/FA docs | Implemented; historical gate incomplete | Offline bilingual playground and EN/FA repository docs pass build/browser/link checks; no annotated `m8` tag |
-| M9 release/integrations | Partial | Package release side is complete: clean committed checkout, public npm artifacts, provenance, trusted publishing, SBOM, retained manifest, immutable `v0.3.2` web release, and signed `android-v0.1.1` Maven release. One host-tested native implementation merged upstream, but the required three integrations, downstream pilots, and adoption evidence remain incomplete |
+| M9 release/integrations | Partial | Package release side is complete: clean committed checkout, public npm artifacts, provenance, trusted publishing, SBOM, retained manifest, immutable `v0.3.3` web release, and signed `android-v0.1.2` Maven release. One host-tested native implementation merged upstream, but the required three integrations, downstream pilots, and adoption evidence remain incomplete |
 
 ## Definition-of-done audit
 
@@ -175,7 +175,7 @@ tag. Therefore working code alone cannot make an historical milestone green.
 | 12 | Complete for current packages — workflows validate, SBOM/license/notices exist |
 | 13 | Partial — one host-tested native implementation is merged; fewer than three integrations exist and no downstream pilot is evidenced |
 | 14 | Complete for current documented claims; continue checking after every change |
-| 15 | Partial — the reviewed source, current `v0.3.2` web release, and `android-v0.1.1` Maven release are public, but historical intermediate milestone tags were not fabricated retroactively |
+| 15 | Partial — the reviewed source, current `v0.3.3` web release, and `android-v0.1.2` Maven release are public, but historical intermediate milestone tags were not fabricated retroactively |
 
 ## Prior-attempt idea coverage
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,9 +31,9 @@ implementation or adoption claim.
   an annotated source tag, and a protected human-approved release workflow.
 - native Android Kotlin core, Views and Compose adapters, photographed-case
   sample, generated 932-case corpus, JVM/Robolectric tests, lint/AAR/APK gates,
-  API 35 plus local API 36.1 UI tests, signed Maven Central `0.1.1`
-  publication, reviewed source candidate `0.1.2`, and independently verified
-  public-consumer resolution.
+  API 35 plus local API 36.1 UI tests, signed Maven Central `0.1.2`
+  publication with combining-mark parity and host-state ownership fixes, and
+  independently verified public-consumer resolution.
 
 ## Implemented in source; native release evidence pending
 
@@ -59,7 +59,7 @@ validation claims. The Rust core also has no editor-specific adapter yet.
   [accessibility checklist](ACCESSIBILITY.md);
 - external security review appropriate to the deployment risk;
 - a downstream pilot in a real AI interface with performance and rollback data;
-- maintainer review and disposition of the submitted host integration and
+- maintainer review and disposition of the two open host integration PRs and
   evidence bundles in the [public outreach log](OUTREACH_LOG.md);
 - an additional maintainer-controlled private conduct channel if community
   activity expands beyond GitHub.
@@ -72,9 +72,10 @@ validation claims. The Rust core also has no editor-specific adapter yet.
 - CSP-safe VS Code extension demonstration;
 - secure Electron example with clipboard and print/PDF verification;
 - browser HTML-to-PDF conformance;
-- two additional host-tested patch-quality upstream integrations; the first
-  submitted patch and current evidence bundles are recorded in the [outreach
-  log](OUTREACH_LOG.md).
+- two additional accepted host-tested patch-quality upstream integrations; the
+  first native implementation is merged in Streamdown, while Hermes and Cline
+  remain open. The current code PRs and evidence bundles are recorded in the
+  [outreach log](OUTREACH_LOG.md).
 
 The complete specification-to-evidence audit lives in
 [REQUIREMENT_MATRIX.md](REQUIREMENT_MATRIX.md).

--- a/docs/V1_BUILD_REPORT.md
+++ b/docs/V1_BUILD_REPORT.md
@@ -1,28 +1,25 @@
 # BidiLens current verification and release report
 
-> This report separates reviewed source candidates from immutable publication
-> history. Web/package `0.3.3` and Android `0.1.2` are the current source
-> candidates; they are not public registry releases until protected publication
-> and clean registry-only consumer verification succeed. Web/package `0.3.2`
-> and Android `0.1.1` remain the latest verified public releases. Publication
-> evidence is retained by the protected workflows and GitHub releases below.
+> This report separates verified publication from broader production claims.
+> Web/package `0.3.3` and Android `0.1.2` are public, with protected publication,
+> registry-only consumer checks, and immutable release evidence. That does not
+> certify every language, device, accessibility path, or downstream application.
 
 **Current-tree evidence date:** 2026-09-02
 
 **License:** MIT, with Unicode-data and Apache-2.0 corpus third-party notices
 
-**Publication status:** all 12 `0.3.2` packages are public with verified
+**Publication status:** all 12 `0.3.3` packages are public with verified
 registry integrity, `latest` tags, and SLSA provenance; exact source commit
-`97f4827a9683c343a92f4ff31f4fa1fc0a718e99` has an annotated `v0.3.2` tag and an
+`51dcd971efa5873a393b90cb6311c73f4315b8e8` has an annotated `v0.3.3` tag and an
 immutable GitHub release containing the retained tarballs, release manifest,
-and CycloneDX 1.7 SBOM. The prior `0.3.1` release remains immutable and
-reproducible. The native Android `0.1.1` core, Views, and Compose modules are
-signed and public on Maven Central with an annotated tag, immutable release, and
-public-consumer evidence. Source versions `0.3.3` and Android `0.1.2` remain
-unpublished candidates and are not included in those public-release claims.
+and CycloneDX 1.7 SBOM. Earlier releases remain immutable historical archives.
+The native Android `0.1.2` core, Views, and Compose modules from the same
+source commit are signed and public on Maven Central with an annotated tag,
+immutable release, and public-consumer evidence.
 
-**Recommendation:** suitable for bounded, maintainer-controlled web pilots;
-not a universal cross-platform production release
+**Recommendation:** suitable for bounded, maintainer-controlled web and Android
+pilots; not a universal cross-platform production release
 
 ## Mission and architecture
 
@@ -46,7 +43,7 @@ opposite-direction runs.
 | `@bidilens/core` | Complete and tested | Unicode analysis, raw and policy-adjusted evidence, configurable technical vocabulary, dual-offset isolation, security, revisable streaming with tested final chunk invariance, properties; 96.32% lines |
 | `@bidilens/dom` | Complete and tested | apply/restore, custom selectors, styles, observer lifecycle, detached/cross-realm DOM |
 | `@bidilens/html` | Complete and tested | escaped semantic blocks and `<bdi>` isolation, tag validation, source preservation |
-| `@bidilens/markdown` | Complete and tested | unified/remark/rehype and typed Markdown-It batch adapters; blocks/lists/tables/quotes/code/math/XSS; rich Markdown-It stream with AST/HTML/isolation/security final parity, dirty/pending ranges, and 97.29% lines |
+| `@bidilens/markdown` | Complete and tested | unified/remark/rehype and typed Markdown-It batch adapters; blocks/lists/tables/quotes/code/math/XSS; rich Markdown-It stream with AST/HTML/isolation/security final parity, dirty/pending ranges, and 97.30% lines |
 | `@bidilens/playwright` | Complete and tested | reusable direction/source/isolation/selection/clipboard/geometry assertions; 100% lines and real three-browser use |
 | `@bidilens/react` | Complete and tested | SSR-safe components, per-paragraph mixed-stream rendering, isolation, direction and stream hooks |
 | `@bidilens/spec` | Complete and tested | five versioned language-neutral schema documents, strict registry API, dual-offset compatibility, real-output and negative validation tests |
@@ -59,12 +56,12 @@ opposite-direction runs.
 | React/Vite playground | Complete and tested | Static/offline; EN/FA UI, policy/security controls, adjustable stream, live four-way comparison, AST/evidence/isolation/security, searchable 932-case asset, copy verification, JSON/semantic HTML export, hash state and explicit theme; three-browser flow |
 | Corpus | Partial (with exact missing functionality) | 932 schema-valid technical/user cases, including 196 attributed sibling seeds; zero native-speaker-certified templates |
 | VS Code, Electron, PDF | Unsupported (with technical reason) | No implementations exist; hollow packages were rejected and these require host-specific security/print tests |
-| Native Android | Implemented; `0.1.1` published and `0.1.2` in source review | Signed Maven Central `0.1.1` core, Views, and Compose artifacts; source candidate `0.1.2` adds combining-mark parity and host-property ownership fixes; sample APK; 932-case verification; JVM/Robolectric tests; lint/AAR build; isolated Maven-local consumer; and API 35/36 emulator UI evidence |
+| Native Android | Implemented; `0.1.2` published | Signed Maven Central core, Views, and Compose artifacts with combining-mark parity and host-property ownership fixes; sample APK; 932-case verification; 31 core, 13 Views, and 9 Compose JVM tests; lint/AAR build; isolated Maven-local and public-only consumers; and API 35/36 emulator UI evidence |
 | Apple Swift/UIKit/SwiftUI | Implemented in source; registry and physical-device validation pending | Swift Package, generated Unicode 17 tables, 932-case corpus tests, UIKit adapters, UIKit-backed SwiftUI `BidiText`, independent physical alignment, and hosted macOS/iOS Simulator gates |
 | Windows .NET/WPF | Implemented in source; NuGet and physical-device validation pending | Dependency-free .NET 8 core, WPF adapters, 932-case executable corpus gate, state/selection restoration, physical-left RTL test, sample, build and package gates |
 | Rust | Implemented in source; crates.io and downstream validation pending | Native core, generated Unicode 17 tables, byte/UTF-16/code-point offsets, 932-case conformance, Linux/macOS/Windows CI, and a runnable example |
 | Flutter and React Native | Unsupported (with technical reason) | No implementations, generated corpus representations, package builds, widget tests, or host integration evidence exist in this repository |
-| Upstream AI-product integrations | External review in progress; no adoption | One host-tested Hermes TUI patch is submitted as [NousResearch/hermes-agent#72508](https://github.com/NousResearch/hermes-agent/pull/72508); tailored evidence requests are public for six additional project families. No review, merge, pilot, deployment, or endorsement is claimed; see the [outreach log](OUTREACH_LOG.md). |
+| Upstream AI-product integrations | One native implementation merged; two code PRs open | [Streamdown #569](https://github.com/vercel/streamdown/pull/569) is merged as a dependency-free native patch. [Hermes #72508](https://github.com/NousResearch/hermes-agent/pull/72508) and [Cline #12724](https://github.com/cline/cline/pull/12724) remain open. A merge is not evidence of BidiLens dependency adoption, a production pilot, or company endorsement; see the [outreach log](OUTREACH_LOG.md). |
 
 ## Reproduced validation
 
@@ -89,24 +86,24 @@ opposite-direction runs.
 | Supported Node probes | built core and CLI pass Node 22.22.1 and 24.18.0; an additional Node 20.19.5 compatibility probe passed, but that EOL line is not a production support claim |
 | Packed framework peer probes | shipped examples pass React/React DOM 18.3.1, Vue/server-renderer 3.5.0, and Svelte 4.2.20; the primary consumer covers React 19.2.8, Vue 3.5.40, and Svelte 5 |
 | `pnpm run release:check` | strict clean-worktree build/pack/inspect/install/type/runtime/CLI consumer passes; exact examples extracted from all 12 tarballs execute. The pre-commit development tree also passed with `--allow-dirty` |
-| `pnpm run npm:release:dry-run -- --version 0.3.2` | all 12 aligned tarballs packed successfully before publication; no registry mutation occurred |
-| GitHub CI for release PR | [PR #72 CI](https://github.com/CodeinScrubs/BidiLens/actions/runs/33505389242) passed all 24 required contexts, including Node 22/24, packed consumers, Windows/macOS, three browser engines, Android API 35, Apple, Windows/.NET, Rust on three OSes, audit/SBOM, workflow lint, Markdown-It 13/14/15, and five-language CodeQL |
-| Protected npm publication | [workflow run `33508856274`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33508856274) passed the full release gate, published all 12 `0.3.2` packages through OIDC trusted publishing, verified registry integrity/provenance, and retained the exact tarballs and manifest |
-| Immutable GitHub release | [`v0.3.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.2) resolves to published commit `97f4827a9683c343a92f4ff31f4fa1fc0a718e99`; GitHub reports the release immutable and records SHA-256 digests for all 12 package tarballs, the release manifest, and CycloneDX 1.7 SBOM |
-| External npm consumer | all 12 public packages installed from the registry; runtime imports, mixed Persian/English direction, streaming, CLI, and the pure-LTR no-op passed; current production dependency audit reported zero findings |
-| Android release CI | [13/13 jobs passed](https://github.com/CodeinScrubs/BidiLens/actions/runs/30337482079), including Android libraries/sample, isolated Maven consumer, and API 35 device tests |
-| Protected Android publication | [workflow run `30339097846`](https://github.com/CodeinScrubs/BidiLens/actions/runs/30339097846) signed and published all three Android `0.1.1` modules to Maven Central |
+| `pnpm run npm:release:dry-run -- --version 0.3.3` | all 12 aligned tarballs packed successfully before publication; no registry mutation occurred |
+| GitHub CI for release PR | [PR #79 CI](https://github.com/CodeinScrubs/BidiLens/actions/runs/33589740575) passed all 19 jobs, including Node 22/24, packed consumers, Windows/macOS, three browser engines, Android API 35, Apple, Windows/.NET, Rust on three OSes, audit/SBOM, workflow lint, and Markdown-It 13/14/15. All five [CodeQL analyses](https://github.com/CodeinScrubs/BidiLens/actions/runs/33589740613) also passed: 24 required contexts in total |
+| Protected npm publication | [workflow run `33591632030`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33591632030) passed the full release gate, published all 12 `0.3.3` packages through OIDC trusted publishing, verified registry integrity/provenance, and retained the exact tarballs and manifest |
+| Immutable GitHub release | [`v0.3.3`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3) resolves to published commit `51dcd971efa5873a393b90cb6311c73f4315b8e8`; GitHub reports the release immutable and records SHA-256 digests for all 12 package tarballs, the release manifest, and CycloneDX 1.7 SBOM |
+| External npm consumer | all 12 public `0.3.3` packages installed from the registry; strict TypeScript, adapter/runtime imports, mixed Persian/English direction, source preservation, streaming, CLI, and pure-LTR no-op passed. `npm audit signatures` verified 114 signatures and 53 attestations across the installed dependency tree |
+| Android release CI | [PR #79 CI](https://github.com/CodeinScrubs/BidiLens/actions/runs/33589740575) passed the Android libraries/sample, isolated Maven consumer, and API 35 device jobs |
+| Protected Android publication | [workflow run `33610612564`](https://github.com/CodeinScrubs/BidiLens/actions/runs/33610612564) signed and published all three Android `0.1.2` modules to Maven Central |
 | Public Maven consumer | all 15 primary files matched retained workflow bytes; 15 detached signatures and 30 Central checksums verified; an empty-Maven-Local consumer resolved all three public coordinates and built |
-| Immutable Android release | [`android-v0.1.1`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.1) resolves to the exact published commit and retains the AARs, sample APK, Maven repository, Central evidence, public key, and SHA-256 checksums |
+| Immutable Android release | [`android-v0.1.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2) resolves to the exact published commit and retains the AARs, sample APK, Maven repository, Central evidence, public key, and SHA-256 checksums |
 
 ## Post-release outreach evidence
 
-The outreach recorded before and after `0.3.1` remains independent of publication. The
-[outreach log](OUTREACH_LOG.md) links every live route, records one focused
-host-code PR, explains why other routes are issue/discussion proposals, and
-lists deliberate anti-spam deferrals. This activity does not change the
-published package bytes and does not count as an audit, merge, pilot,
-production deployment, adoption, or company endorsement.
+Outreach remains independent of publication. The [outreach log](OUTREACH_LOG.md)
+links every live route, records the merged Streamdown native patch and two
+open host-code PRs, explains the issue/discussion routes, and lists deliberate
+anti-spam deferrals. Only the Streamdown change has a verified upstream merge;
+neither submissions nor that merge establish a downstream pilot, production
+deployment, BidiLens dependency adoption, or company endorsement.
 
 Visual coverage includes the four-way flagship comparison, geometry, English
 mirror, per-paragraph direction, logical selection in three engines, actual
@@ -120,7 +117,7 @@ Aggregate emitted JavaScript, including chunks and before minification/gzip:
 | Package | Bytes | Enforced budget |
 |---|---:|---:|
 | CLI | 16,330 | 32,768 |
-| Core | 126,825 | 126,976 |
+| Core | 112,136 | 126,976 |
 | DOM | 18,321 | 20,480 |
 | HTML | 4,361 | 12,288 |
 | Markdown | 79,833 | 81,920 |
@@ -130,19 +127,20 @@ Aggregate emitted JavaScript, including chunks and before minification/gzip:
 | Svelte | 1,855 | 8,192 |
 | Terminal | 4,273 | 8,192 |
 | Vue | 4,553 | 12,288 |
-| Web Component | 37,391 | 81,920 |
+| Web Component | 29,960 | 81,920 |
 
-The core artifact is 26,941 bytes with gzip and 20,257 bytes with Brotli on
-this build. Its unminified increase funds exact batch/final token-policy parity,
-invisible-character auditing, atomic control-family sanitization, and
-closed-fence recognition across the tested token grammar and stream chunk
-boundaries; applications that do not import the stream API can still tree-shake
-that implementation. Live snapshots remain intentionally revisable while an
-unfinished token can still change classification; `finish()` is the exact
+On 2026-09-02, Node 25.2.1's default zlib settings measured the core entry at
+23,421 bytes with gzip and 19,601 bytes with Brotli. Compact generated Unicode
+range encoding reduces the emitted core and standalone Web Component while
+retaining the checksum-derived classification tables and test coverage. These
+are build-artifact measurements, not cross-runtime compression guarantees.
+Applications that do not import the stream API can still tree-shake that
+implementation. Live snapshots remain intentionally revisable while an
+unfinished token can change classification; `finish()` is the exact
 finalization boundary.
 
-The Markdown artifact is 15,053 bytes with gzip and 13,111 bytes with Brotli on
-this build. Its increase contains the serializable token AST, block-analysis
+The Markdown artifact is 15,135 bytes with gzip and 13,111 bytes with Brotli on
+the same build. It contains the serializable token AST, block-analysis
 report, security deltas, dirty/pending range protocol, geometric and
 context-changing structural checkpoints, bounded grammar-aware provisional
 state, and exact final reconciliation. Markdown-It remains a caller-owned
@@ -211,11 +209,12 @@ native/desktop ideas found in sibling documentation are retained in the
 
 ## Release decision
 
-The `0.3.2` code artifacts are published as a **maintainer-controlled public
-web beta**. npm publication, package provenance, registry-integrity
-verification, per-package trusted publishing, protected human approval, the
-annotated `v0.3.2` tag, and the immutable release are complete. Broad rollout
-still requires:
+The `0.3.3` web packages and Android `0.1.2` modules are published for
+**maintainer-controlled, bounded pilots**. npm and Maven publication, package
+provenance/signatures, registry-integrity verification, per-package trusted
+publishing, protected human approval, the annotated `v0.3.3` and
+`android-v0.1.2` tags, and immutable releases are complete. Broad rollout still
+requires:
 
 1. final name/trademark review appropriate to the adopter;
 2. native-language and accessibility review appropriate to claims;
@@ -226,9 +225,9 @@ Broad production or “all platforms” readiness is **not** claimed. Native
 Android Kotlin, Views, and Compose modules now have JVM, lint, sample-app, and
 emulator evidence plus signed Maven Central distribution, but physical OEM/IME
 and TalkBack validation, physical iOS/VoiceOver and Windows accessibility/IME
-labs, native registry publication beyond Android, PDF support, upstream
-integrations, native-speaker certification, an external security audit, and a
-real downstream pilot remain absent. Historical milestone tags between `m1`
-and the current `v0.3.2` release tag were not retroactively fabricated;
+labs, native registry publication beyond Android, PDF support, additional
+upstream integrations, native-speaker certification, an external security audit,
+and a real downstream pilot remain incomplete. Historical milestone tags
+between `m1` and the current `v0.3.3` release tag were not retroactively fabricated;
 publishing the reviewed source does not reconstruct the original stepwise tag
 history.

--- a/packages/web-component/README.md
+++ b/packages/web-component/README.md
@@ -33,7 +33,7 @@ purpose, contains no bare package imports, and registers `<bidi-message>`:
 ```html
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 <script type="module"
-  src="https://unpkg.com/@bidilens/web-component@0.1.1/dist/standalone.js"></script>
+  src="https://unpkg.com/@bidilens/web-component@0.3.3/dist/standalone.js"></script>
 ```
 
 Applications with a bundler should prefer the side-effect-free normal entry


### PR DESCRIPTION
## Summary

- Record completed npm `0.3.3` and Android `0.1.2` publication from exact source
  `51dcd971efa5873a393b90cb6311c73f4315b8e8`, with protected workflow, registry,
  public-consumer, and immutable-release evidence.
- Update English/Persian installation guides, Android instructions, CDN
  examples, release/requirement/impact reports, roadmap, and outreach kit.
- Preserve historical publication/outreach snapshots; distinguish Streamdown's
  native-patch merge from the still-open Hermes/Cline PRs and from dependency
  adoption. A focused new project-mail search found only npm publication
  notices; no new reply or outgoing outreach is claimed.
- Correct current test, coverage, artifact-size, and SBOM totals; explicitly
  document minimal Maven documentation jars and the debug-only sample APK.
- Separate Android settings-level repository configuration from app-module
  dependencies so the installation snippets have an unambiguous destination.

Documentation only: no runtime source, dependency, release artifact, tag target,
or published package bytes are changed. The Web Component README correction
updates repository guidance; already-published tarballs remain immutable.

## Verification

- `pnpm run check`: 439 tests, 932 corpus cases, Unicode/type/lint/depth checks,
  all packages/demo/Action builds, and built-Action probes passed.
- `pnpm run docs:check`: 70 Markdown files and 83 local links passed after the
  final documentation edits; `git diff --check` passed.
- `pnpm run release:check`: all 12 package archives, size budgets, a clean
  TypeScript/runtime/CLI consumer, and every packed example passed on the final
  documentation commit. This was a verification run, not a new publication.
- Current core/Markdown/Web Component emitted sizes and gzip/Brotli totals were
  recomputed from the build and match the report.
- npm run [33591632030](https://github.com/CodeinScrubs/BidiLens/actions/runs/33591632030):
  all 12 registry packages, integrity/provenance, and an independent strict
  registry-only consumer verified.
- Android run [33610612564](https://github.com/CodeinScrubs/BidiLens/actions/runs/33610612564):
  15 public primary files match retained bytes, 15 signatures and 30 Central
  checksums verify, and a clean consumer downloaded all three AARs from Central
  with empty Maven Local and compiled successfully.
- Immutable releases [v0.3.3](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3)
  and [android-v0.1.2](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2):
  exact annotated-tag targets and every GitHub asset SHA-256 digest verified.

Independent review of both documentation commits found no actionable issues.
Protected auto-merge is enabled for the final head; all required CI/CodeQL
contexts must pass before GitHub can merge it. Publication does not certify
universal rendering, accessibility/device labs, a production pilot, or company
adoption.
