### PR TITLE
fix(deps): unblock fast-uri security updates

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -77,6 +77,16 @@ It cannot decide whether every control is malicious. Host applications should
 combine structured findings with file type, syntax, user trust, and review
 policy.
 
+## Development dependency maintenance
+
+The workspace pins `fast-uri` to `3.1.6`, which includes the upstream fixes for
+GHSA-jqff-g426-hqxp, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, and
+GHSA-5jgf-p345-68v8. These advisories concern URI normalization and host
+confusion; the dependency is used by development/schema-validation tooling.
+The pin and lockfile must be updated together when a new patch is needed:
+an exact override can prevent Dependabot from resolving an otherwise available
+security update. Run `pnpm run deps:audit` after updating the lockfile.
+
 ## Responsible disclosure
 
 The repository-level `SECURITY.md` records the current reporting channel. A

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "overrides": {
       "brace-expansion": "5.0.9",
       "esbuild": "0.28.2",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.6",
       "js-yaml@3": "3.15.1",
       "js-yaml@4": "4.3.1",
       "nanoid": "3.3.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   brace-expansion: 5.0.9
   esbuild: 0.28.2
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   js-yaml@3: 3.15.1
   js-yaml@4: 4.3.1
   nanoid: 3.3.18
@@ -1474,8 +1474,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3317,7 +3317,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3629,7 +3629,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
## What changed

Updates the exact `fast-uri` override and lockfile from 3.1.5 to 3.1.6. The old pin blocked Dependabot from installing the available patch for four high-severity URI-normalization advisories (repository alerts 13–16): GHSA-jqff-g426-hqxp, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, and GHSA-5jgf-p345-68v8.

The dependency is reached through development dependency `ajv`; no public API, bidi policy, or published-package version changes. The security guide documents the override/lockfile maintenance requirement.

## Evidence

- `pnpm install --frozen-lockfile`: passed after regenerating the lockfile; only fast-uri's resolved version/integrity changed.
- `pnpm run deps:audit`: no known vulnerabilities.
- `pnpm run check`: passed, including 439 tests, 932 corpus fixtures, typecheck, lint, documentation, build and bundled Action probes.
- `pnpm run packages:types`: all 12 package layouts passed.
- `pnpm run release:check -- --allow-dirty`: all 12 tarballs and strict consumers/packed examples passed. This checks local artifacts and does not republish 0.3.3.
- `pnpm why fast-uri`: only the patched 3.1.6 through development `ajv`.
- Independent review checked all four upstream advisories, the diff, audit, spec tests and corpus.

Local runtime: Windows / Node 25.2.1. Protected CI supplies supported Node 22/24 and native/platform coverage before merge. Rendering and detection implementation are unchanged; the existing ordinary-RTL false-positive tests passed in the full check.
