### PR TITLE
docs: record verified npm 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ is published under the public `@bidilens` npm scope.
 
 No unreleased changes.
 
-## 0.4.0 - release prepared; publication pending
+## 0.4.0 - 2026-09-07
 
 ### Easier, bounded integration
 
@@ -33,6 +33,9 @@ No unreleased changes.
   findings. No runtime dependency was added.
 - All 12 npm packages align at `0.4.0`; unchanged packages move with the fixed
   release group. Android remains at the verified public `0.1.2` release.
+- Published all 12 packages through the protected OIDC workflow, verified the
+  exact public bytes/provenance and a registry-only consumer, and retained the
+  artifacts and SBOM in the immutable `v0.4.0` release.
 
 ## 0.3.3 - 2026-09-02
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -13,18 +13,17 @@
 [مشارکت](CONTRIBUTING.md) · [وضعیت پروژه](docs/V1_BUILD_REPORT.md)
 
 > [!IMPORTANT]
-> این checkout برای نسخهٔ npm `0.4.0` آماده شده است؛ انتشار آن هنوز در انتظار
-> بررسی‌ها و فرایند انتشار محافظت‌شده است. نسخهٔ عمومی تأییدشده تا پایان این
-> فرایند همان `0.3.3` است.
->
-> نسخهٔ `0.3.3` بخش وب و JavaScript برای هر ۱۲ بستهٔ `@bidilens/*` در npm
+> نسخهٔ `0.4.0` بخش وب و JavaScript برای هر ۱۲ بستهٔ `@bidilens/*` در npm
 > عمومی است و یکپارچگی رجیستری و SLSA provenance آن‌ها تأیید شده است؛ tarballها،
 > manifest و SBOM دقیق آن در
-> [انتشار تغییرناپذیر `v0.3.3`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3)
+> [انتشار تغییرناپذیر `v0.4.0`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.4.0)
 > نگه‌داری می‌شود. این نسخه پس از عبور از گیت کامل انتشار، از commit محافظت‌شدهٔ
-> `51dcd971efa5873a393b90cb6311c73f4315b8e8` منتشر شده است. نسخهٔ `0.1.2`
-> هستهٔ Kotlin و ماژول‌های Android Views و Jetpack Compose نیز از همین commit،
-> امضاشده و در Maven Central عمومی است؛ فایل‌های AAR، برنامهٔ نمونه، شواهد
+> `46b9b21c6b58cdaa7b0b5e3473aa253ee6c07e52` منتشر شده است. راهنمای ادغام آفلاین
+> و محافظت بهتر از نواحی مستثناشدهٔ DOM در نسخهٔ `0.4.0` اضافه شده‌اند.
+> هستهٔ Kotlin و ماژول‌های Android Views و Jetpack Compose همچنان در نسخهٔ
+> `0.1.2` باقی می‌مانند؛ انتشار جداگانهٔ آن‌ها از commit
+> `51dcd971efa5873a393b90cb6311c73f4315b8e8`، امضاشده و در Maven Central عمومی
+> است. فایل‌های AAR، برنامهٔ نمونه، شواهد
 > امضا و checksum و نتیجهٔ آزمون مصرف‌کنندهٔ تمیز از رجیستری عمومی در
 > [انتشار تغییرناپذیر `android-v0.1.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
 > ثبت شده‌اند. نسخه‌های پیشین نیز به‌صورت آرشیو تغییرناپذیر در دسترس هستند.
@@ -93,9 +92,9 @@ The Persian word کتاب means “book”.
 Compose و Views در [راهنمای Android](android/README.md) قرار دارد.
 
 تمام بسته‌های عمومی ESM-only هستند و برای استفادهٔ سمت سرور به Node.js 22.12 یا
-جدیدتر نیاز دارند. مجموعهٔ کامل `0.3.3` در
+جدیدتر نیاز دارند. مجموعهٔ کامل `0.4.0` در
 [سازمان `@bidilens` در npm](https://www.npmjs.com/org/bidilens) منتشر شده است؛
-مجموعه‌های `0.3.2` و `0.3.1` نیز به‌عنوان نسخه‌های تاریخی تغییرناپذیر باقی مانده‌اند.
+مجموعه‌های `0.3.3`، `0.3.2` و `0.3.1` نیز به‌عنوان نسخه‌های تاریخی تغییرناپذیر باقی مانده‌اند.
 
 پروژه با [مجوز MIT](LICENSE) متن‌باز است. شرایط داده‌های Unicode و بخش
 Apache-2.0 پیکره در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) حفظ شده
@@ -109,7 +108,7 @@ Apache-2.0 پیکره در [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) حف
 استفاده است:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.3"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.4.0"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,16 @@ recipes, compatibility checks, and rollback. You do not need every package
 or a project-wide RTL migration.
 
 > [!IMPORTANT]
-> This checkout prepares npm `0.4.0` with offline integration guidance and
-> safer DOM exclusions. Publication is pending the protected release process;
-> the verified public release described below remains `0.3.3` until that completes.
->
-> The JavaScript/web `0.3.3` release is public across all 12 `@bidilens/*`
+> The JavaScript/web `0.4.0` release is public across all 12 `@bidilens/*`
 > packages with verified registry integrity and SLSA provenance; its exact
 > tarballs, manifest, and SBOM are retained in the immutable
-> [`v0.3.3` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.3.3).
+> [`v0.4.0` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.4.0).
 > It was published from protected `main` commit
-> `51dcd971efa5873a393b90cb6311c73f4315b8e8` after the complete release gate.
-> Native Android core, Views, and Compose `0.1.2` artifacts from the same
-> commit are signed and public on Maven Central. Their AARs, sample APK,
+> `46b9b21c6b58cdaa7b0b5e3473aa253ee6c07e52` after the complete release gate.
+> Version `0.4.0` adds offline integration guidance and safer DOM exclusions.
+> Native Android core, Views, and Compose remain at signed Maven Central
+> version `0.1.2`, published separately from commit
+> `51dcd971efa5873a393b90cb6311c73f4315b8e8`. Their AARs, sample APK,
 > public signature/checksum evidence, and clean public-consumer verification
 > are recorded in the immutable
 > [`android-v0.1.2` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2).
@@ -187,9 +185,9 @@ reordering and shaping; BidiLens supplies the application structure they need.
 
 All public packages are ESM-only, require maintained Node.js 22.12 or newer for
 server-side use, include declarations, a package README, license, and runnable example.
-Browser packages target current standards-based browsers. The complete `0.3.3`
+Browser packages target current standards-based browsers. The complete `0.4.0`
 package set is [published under the `@bidilens` npm scope](https://www.npmjs.com/org/bidilens);
-the prior `0.3.2` and `0.3.1` sets remain available as historical releases.
+the prior `0.3.3`, `0.3.2`, and `0.3.1` sets remain available as historical releases.
 
 ## Consumer install
 
@@ -211,7 +209,7 @@ For a no-build browser page, the published Web Component also exposes a
 standalone entry that bundles the core and needs no import map:
 
 ```html
-<script type="module" src="https://unpkg.com/@bidilens/web-component@0.3.3"></script>
+<script type="module" src="https://unpkg.com/@bidilens/web-component@0.4.0"></script>
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -209,9 +209,16 @@ Use [Playwright helpers](../packages/playwright/README.md) and the
 
 ## Offline CLI guidance (0.4.0+)
 
-Version `0.4.0` adds the `guide` command; it is **not in `0.3.3`**. Check the
-[release status](../README.md) before requesting a version from npm. With CLI
-`0.4.0` installed, run `bidilens guide`, `bidilens guide react`, or
+Version `0.4.0` adds the `guide` command; it is **not in `0.3.3`**. To try the
+published CLI without installing it globally:
+
+```bash
+npx --package=@bidilens/cli@0.4.0 bidilens guide react
+npx --package=@bidilens/cli@0.4.0 bidilens guide dom --json
+```
+
+`npx` downloads the package when needed; the guide command itself is offline.
+With CLI `0.4.0` installed, run `bidilens guide`, `bidilens guide react`, or
 `bidilens guide dom --json`. From a source checkout:
 
 ```bash

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -2,23 +2,45 @@
 
 The canonical source is published at
 [`CodeinScrubs/BidiLens`](https://github.com/CodeinScrubs/BidiLens). This
-checklist records the completed web/npm `0.3.3` and Android/Maven `0.1.2`
+checklist records the completed web/npm `0.4.0` and Android/Maven `0.1.2`
 releases, preserves earlier publication evidence, and defines the controls
 required for future releases.
 
-## Pending npm 0.4.0 release
+## Current verified npm release — 2026-09-07
 
-The source checkout prepares the fixed npm package group at `0.4.0` for the
-offline integration guide and protected DOM exclusion fix. Android has no new
-changes requiring publication and remains `0.1.2`. Root/package/demo versions,
-Changesets changelogs, the citation, and the bundled Action must remain aligned.
+All 12 npm packages are public at `0.4.0` from protected `main` commit
+`46b9b21c6b58cdaa7b0b5e3473aa253ee6c07e52`. The integration changes in
+[PR #83](https://github.com/CodeinScrubs/BidiLens/pull/83) and release preparation
+in [PR #84](https://github.com/CodeinScrubs/BidiLens/pull/84) were independently
+reviewed. The release candidate passed all 19
+[CI jobs](https://github.com/CodeinScrubs/BidiLens/actions/runs/34053633393) and
+five [CodeQL analyses](https://github.com/CodeinScrubs/BidiLens/actions/runs/34053633462).
+Its reviewed head and merged commit share tree
+`8769b57e5837f67c51d2a9c5d12ee1e415459138`.
 
-Do not treat this preparation as registry availability. Publish only after the
-reviewed release commit passes the complete protected matrix, then verify
-registry integrity/provenance and a clean registry-only consumer. Retain the
-exact publishing-run tarballs and SBOM in the immutable `v0.4.0` release.
+- Protected npm run
+  [`34104056339`](https://github.com/CodeinScrubs/BidiLens/actions/runs/34104056339)
+  repeated the quality, audit, and clean packed-consumer gates, then published
+  the complete fixed group through OIDC. No new npm token was required.
+- Independent verification matched all 12 retained/public tarball bytes,
+  SHA-256 and registry SHA-512 integrity, `latest@0.4.0`, and SLSA provenance
+  tied to that source commit and publishing workflow. A fresh registry-only
+  consumer passed strict TypeScript, runtime/source-preservation/LTR checks,
+  protected DOM exclusion, installed CLI guidance and corpus tests, and
+  cryptographic verification with `npm audit signatures` (115 verified registry
+  signatures and 54 attestations across the whole consumer dependency tree).
+- Annotated tag and immutable release
+  [`v0.4.0`](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.4.0) retain
+  the exact 12 tarballs, publication manifest, independent registry evidence,
+  and validated CI CycloneDX 1.7 SBOM. GitHub asset digests match local SHA-256;
+  the signed release attestation was verified.
 
-## Current verified releases — 2026-09-02
+Android has no new source changes in this release and remains at public
+`0.1.2`, tied to its earlier source commit and evidence below. Apple, Windows,
+and Rust implementations remain source-distributed; this npm release does not
+claim native registry publication or physical-device/accessibility certification.
+
+## Earlier npm release and current Android evidence — 2026-09-02
 
 Web/package `0.3.3` and Android `0.1.2` are public from protected `main` commit
 `51dcd971efa5873a393b90cb6311c73f4315b8e8`. The release preparation in
@@ -134,13 +156,13 @@ new version.
 - MIT project license plus Unicode and imported-corpus notices;
 - human-controlled release preparation and protected npm publication
   workflows;
-- all 12 `@bidilens/*@0.3.3` packages published publicly with SLSA provenance;
+- all 12 `@bidilens/*@0.4.0` packages published publicly with SLSA provenance;
 - retained release tarballs whose SHA-512 values match the public registry;
 - per-package GitHub OIDC trusted publishers bound to `publish.yml` and the
   protected `npm-release` environment;
 - token-based publishing disabled through npm's recommended
   `Require two-factor authentication and disallow tokens` package setting;
-- annotated `v0.3.3` tag and immutable GitHub release for the exact published
+- annotated `v0.4.0` tag and immutable GitHub release for the exact published
   source commit, with all package tarballs, release manifest, and SBOM attached;
 - signed Android `0.1.2` artifacts published under the verified
   `io.github.codeinscrubs.bidilens` namespace, with protected release evidence,

--- a/docs/V1_BUILD_REPORT.md
+++ b/docs/V1_BUILD_REPORT.md
@@ -1,25 +1,40 @@
 # BidiLens current verification and release report
 
 > This report separates verified publication from broader production claims.
-> Web/package `0.3.3` and Android `0.1.2` are public, with protected publication,
+> Web/package `0.4.0` and Android `0.1.2` are public, with protected publication,
 > registry-only consumer checks, and immutable release evidence. That does not
 > certify every language, device, accessibility path, or downstream application.
 
-**Current-tree evidence date:** 2026-09-06
+**Current-tree evidence date:** 2026-09-07
 
-## 0.4.0 preparation — 2026-09-06
+## Current 0.4.0 release evidence — 2026-09-07
 
-The current source prepares npm `0.4.0`; registry publication is pending.
-Android stays at `0.1.2`. The earlier publication evidence below remains a
-historical record and is not a claim that `0.4.0` has been published.
+All 12 npm `0.4.0` packages are public from protected source commit
+`46b9b21c6b58cdaa7b0b5e3473aa253ee6c07e52`; Android stays at its separately
+published `0.1.2`. [PR #84](https://github.com/CodeinScrubs/BidiLens/pull/84)
+passed all [19 CI jobs](https://github.com/CodeinScrubs/BidiLens/actions/runs/34053633393)
+and [five CodeQL analyses](https://github.com/CodeinScrubs/BidiLens/actions/runs/34053633462).
+The reviewed and merged trees match exactly. Protected npm run
+[`34104056339`](https://github.com/CodeinScrubs/BidiLens/actions/runs/34104056339)
+repeated the release gates and published through OIDC.
 
 The integration change passed 479 tests in 19 files, with 92.32% statements,
 86.43% branches, 95.02% functions, and 95.07% lines. All 12 packed packages,
 declaration layouts, executable package examples, and the four actual CLI
 recipes passed consumer checks. The new editor exclusion regression passed
-in Chromium, Firefox, and WebKit. Hosted Firefox/WebKit passed; a local
+in Chromium, Firefox, and WebKit. All 33 hosted browser tests passed. A local
 Firefox navigation timeout also reproduced against a minimal non-BidiLens
-HTTP server. The full protected matrix must pass on the release commit.
+HTTP server; universal local-browser reliability is not claimed.
+
+All retained/public package bytes, `latest` tags, registry integrity and SLSA
+source provenance were independently verified. A separate registry-only
+consumer passed strict TypeScript, adapter/runtime/source-preservation/LTR,
+guide and DOM-exclusion checks, installed CLI corpus tests, and `npm audit
+signatures`. The annotated immutable
+[`v0.4.0` release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.4.0)
+retains exact artifacts, manifest, public evidence, and a validated CI SBOM
+(523 components, 537 dependency relationships); asset digests and GitHub's
+signed release attestation were verified. See [publication evidence](PUBLISHING.md).
 
 The Start here guide, CLI adapter selection, editor-free starter guard,
 idempotent cleanup, DOM `skipSelector` fix, and AST bundle import audit were
@@ -29,8 +44,8 @@ independently reviewed. No inference policy or native source changed.
 
 **License:** MIT, with Unicode-data and Apache-2.0 corpus third-party notices
 
-**Publication status:** all 12 `0.3.3` packages are public with verified
-registry integrity, `latest` tags, and SLSA provenance; exact source commit
+**Historical publication status:** all 12 `0.3.3` packages were independently
+verified with registry integrity, then-current `latest` tags, and SLSA provenance; exact source commit
 `51dcd971efa5873a393b90cb6311c73f4315b8e8` has an annotated `v0.3.3` tag and an
 immutable GitHub release containing the retained tarballs, release manifest,
 and CycloneDX 1.7 SBOM. Earlier releases remain immutable historical archives.
@@ -61,7 +76,7 @@ opposite-direction runs.
 | Surface | Status | Evidence / boundary |
 |---|---|---|
 | `@bidilens/core` | Complete and tested | Unicode analysis, raw and policy-adjusted evidence, configurable technical vocabulary, dual-offset isolation, security, revisable streaming with tested final chunk invariance, properties; 96.32% lines |
-| `@bidilens/dom` | Complete and tested | apply/restore, custom selectors, styles, observer lifecycle, detached/cross-realm DOM |
+| `@bidilens/dom` | Complete and tested | apply/restore, custom selectors, protected descendant/standalone-code exclusions, styles, observer lifecycle, detached/cross-realm DOM |
 | `@bidilens/html` | Complete and tested | escaped semantic blocks and `<bdi>` isolation, tag validation, source preservation |
 | `@bidilens/markdown` | Complete and tested | unified/remark/rehype and typed Markdown-It batch adapters; blocks/lists/tables/quotes/code/math/XSS; rich Markdown-It stream with AST/HTML/isolation/security final parity, dirty/pending ranges, and 97.30% lines |
 | `@bidilens/playwright` | Complete and tested | reusable direction/source/isolation/selection/clipboard/geometry assertions; 100% lines and real three-browser use |
@@ -71,7 +86,7 @@ opposite-direction runs.
 | `@bidilens/svelte` | Complete and tested | idiomatic analysis and streaming stores |
 | `@bidilens/web-component` | Complete and tested | Side-effect-free main import, explicit/auto registration entries, safe DOM construction, self-contained CDN entry, real three-browser loading |
 | `@bidilens/terminal` | Complete and tested | ANSI-aware conservative output; emulator shaping remains host-dependent |
-| `@bidilens/cli` | Complete and tested | inspect/render/test/audit/lint/security-scan/sanitize; human/JSON/SARIF; real packed binary |
+| `@bidilens/cli` | Complete and tested | offline guide with 12 routes/four tested recipes; inspect/render/test/audit/lint/security-scan/sanitize; human/JSON/SARIF; real packed binary |
 | Bundled GitHub Action | Complete and tested | Node 24 audit/corpus action, human/JSON/SARIF, workspace-safe report path, real exit codes; source and generated-bundle probes |
 | React/Vite playground | Complete and tested | Static/offline; EN/FA UI, policy/security controls, adjustable stream, live four-way comparison, AST/evidence/isolation/security, searchable 932-case asset, copy verification, JSON/semantic HTML export, hash state and explicit theme; three-browser flow |
 | Corpus | Partial (with exact missing functionality) | 932 schema-valid technical/user cases, including 196 attributed sibling seeds; zero native-speaker-certified templates |
@@ -81,9 +96,13 @@ opposite-direction runs.
 | Windows .NET/WPF | Implemented in source; NuGet and physical-device validation pending | Dependency-free .NET 8 core, WPF adapters, 932-case executable corpus gate, state/selection restoration, physical-left RTL test, sample, build and package gates |
 | Rust | Implemented in source; crates.io and downstream validation pending | Native core, generated Unicode 17 tables, byte/UTF-16/code-point offsets, 932-case conformance, Linux/macOS/Windows CI, and a runnable example |
 | Flutter and React Native | Unsupported (with technical reason) | No implementations, generated corpus representations, package builds, widget tests, or host integration evidence exist in this repository |
-| Upstream AI-product integrations | One native implementation merged; two code PRs open | [Streamdown #569](https://github.com/vercel/streamdown/pull/569) is merged as a dependency-free native patch. [Hermes #72508](https://github.com/NousResearch/hermes-agent/pull/72508) and [Cline #12724](https://github.com/cline/cline/pull/12724) remain open. A merge is not evidence of BidiLens dependency adoption, a production pilot, or company endorsement; see the [outreach log](OUTREACH_LOG.md). |
+| Upstream AI-product integrations | Two native contributions merged; two code PRs open (checked 2026-09-07) | [Streamdown #569](https://github.com/vercel/streamdown/pull/569) and [CoderAI #3](https://github.com/mohamadreza1368/coderAI/pull/3) are merged as native fixes without a BidiLens package dependency. [Hermes #72508](https://github.com/NousResearch/hermes-agent/pull/72508) and [Cline #12724](https://github.com/cline/cline/pull/12724) remain open. A merge is not evidence of BidiLens dependency adoption, a production pilot, or company endorsement; see the [outreach log](OUTREACH_LOG.md). |
 
-## Reproduced validation
+## Historical 0.3.3 validation snapshot — 2026-09-02
+
+These exact counts, versions, and commands preserve the earlier release's
+evidence. Current 0.4.0 validation is recorded above; historical `latest` and
+dependency-update results are not current registry claims.
 
 | Command / gate | Observed result |
 |---|---|
@@ -119,10 +138,10 @@ opposite-direction runs.
 ## Post-release outreach evidence
 
 Outreach remains independent of publication. The [outreach log](OUTREACH_LOG.md)
-links every live route, records the merged Streamdown native patch and two
+links every live route, records the merged Streamdown and CoderAI native fixes and two
 open host-code PRs, explains the issue/discussion routes, and lists deliberate
-anti-spam deferrals. Only the Streamdown change has a verified upstream merge;
-neither submissions nor that merge establish a downstream pilot, production
+anti-spam deferrals. The Streamdown and CoderAI changes have verified upstream merges;
+neither submissions nor those merges establish a downstream pilot, production
 deployment, BidiLens dependency adoption, or company endorsement.
 
 Visual coverage includes the four-way flagship comparison, geometry, English
@@ -130,15 +149,15 @@ mirror, per-paragraph direction, logical selection in three engines, actual
 Chromium clipboard text, stream settlement, dark mode/zoom, and structured
 Markdown heading/list/blockquote/table/code output.
 
-## Artifact sizes
+## 0.4.0 artifact sizes
 
 Aggregate emitted JavaScript, including chunks and before minification/gzip:
 
 | Package | Bytes | Enforced budget |
 |---|---:|---:|
-| CLI | 16,330 | 32,768 |
+| CLI | 27,731 | 32,768 |
 | Core | 112,136 | 126,976 |
-| DOM | 18,321 | 20,480 |
+| DOM | 18,465 | 20,480 |
 | HTML | 4,361 | 12,288 |
 | Markdown | 79,833 | 81,920 |
 | Playwright | 8,542 | 16,384 |
@@ -221,18 +240,18 @@ local numbers, not a service-level objective.
 ## Sibling-project comparison
 
 The canonical checkout is the strongest reproducible JavaScript/web
-implementation among the local sibling folders: 12 public packages, 17 test
-files with 439 tests, 932 fixtures, current generated Unicode data, real
+implementation among the audited local sibling folders: 12 public packages, 19 test
+files with 479 tests, 932 fixtures, current generated Unicode data, real
 three-engine visual evidence, and clean package-consumer gates. Broader
 native/desktop ideas found in sibling documentation are retained in the
 [traceability audit](PROJECT_COMPARISON.md), not misrepresented as working code.
 
 ## Release decision
 
-The `0.3.3` web packages and Android `0.1.2` modules are published for
+The `0.4.0` web packages and Android `0.1.2` modules are published for
 **maintainer-controlled, bounded pilots**. npm and Maven publication, package
 provenance/signatures, registry-integrity verification, per-package trusted
-publishing, protected human approval, the annotated `v0.3.3` and
+publishing, protected maintainer approval, the annotated `v0.4.0` and
 `android-v0.1.2` tags, and immutable releases are complete. Broad rollout still
 requires:
 
@@ -248,6 +267,6 @@ and TalkBack validation, physical iOS/VoiceOver and Windows accessibility/IME
 labs, native registry publication beyond Android, PDF support, additional
 upstream integrations, native-speaker certification, an external security audit,
 and a real downstream pilot remain incomplete. Historical milestone tags
-between `m1` and the current `v0.3.3` release tag were not retroactively fabricated;
+between `m1` and the current `v0.4.0` release tag were not retroactively fabricated;
 publishing the reviewed source does not reconstruct the original stepwise tag
 history.

--- a/packages/web-component/README.md
+++ b/packages/web-component/README.md
@@ -33,7 +33,7 @@ purpose, contains no bare package imports, and registers `<bidi-message>`:
 ```html
 <bidi-message text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."></bidi-message>
 <script type="module"
-  src="https://unpkg.com/@bidilens/web-component@0.3.3/dist/standalone.js"></script>
+  src="https://unpkg.com/@bidilens/web-component@0.4.0/dist/standalone.js"></script>
 ```
 
 Applications with a bundler should prefer the side-effect-free normal entry


### PR DESCRIPTION
## Verified publication

Documents the now-public [npm 0.4.0 release](https://github.com/CodeinScrubs/BidiLens/releases/tag/v0.4.0), published by protected run [34104056339](https://github.com/CodeinScrubs/BidiLens/actions/runs/34104056339) from reviewed commit `46b9b21c6b58cdaa7b0b5e3473aa253ee6c07e52`.

- All 12 public tarballs independently match the retained publishing artifacts, SHA-256/registry SHA-512, latest tags, and SLSA source/workflow metadata.
- A separate registry-only consumer installed all 12 exact versions with strict peers and zero audit findings. Strict TypeScript, runtime/adapter/source-preservation/LTR, protected DOM exclusion, offline CLI guidance, and all 932 CLI corpus cases passed.
- `npm audit signatures` verified 115 registry signatures and 54 attestations across that consumer's complete dependency tree.
- Both documented unpkg URLs return bytes matching the installed standalone Web Component.
- Annotated tag v0.4.0 points to the exact published commit. GitHub reports its release immutable with 16 assets; all asset digests match retained local files, and `gh release verify` cryptographically verified GitHub's release attestation.

## Documentation changes

- Update English/Persian front-page publication status and pinned CDN examples.
- Add beginner-friendly, version-pinned `npx` guide commands; distinguish the initial network download from the offline guide command.
- Record current publication evidence while preserving historical 0.3.3 checks and Android 0.1.2's separate original source commit.
- Refresh current test/artifact counts and reconcile the already-merged CoderAI contribution with the existing adoption log. No new outreach was sent.
- Keep native registry, physical-device, accessibility, corpus-review, and broader production boundaries explicit.

## Validation and review

- Documentation gate: 72 Markdown files, 112 local links passed.
- Guide/recipe-drift tests: 29 passed.
- Whitespace check passed.
- Independent read-only review completed; the stale upstream-merge count it found was corrected against live GitHub evidence.
- Exactly seven Markdown files change. No runtime source, manifests, lockfiles, or workflow behavior changes. No npm republish is required for these repository documentation updates.

This PR retains the complete protected CI/security matrix and must merge normally; the already-published artifact/tag is not moved.
