### PR TITLE
docs: make BidiLens easier to evaluate and integrate

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -34,3 +34,9 @@ body:
           required: true
         - label: I searched existing issues and the documented limitations/roadmap.
           required: true
+  - type: input
+    id: discovery
+    attributes:
+      label: How did you find BidiLens? (optional)
+      description: A public post, documentation link, upstream PR, or event name helps us improve our guides. This issue is public; do not include private messages or personal information.
+      placeholder: e.g. a Streamdown PR or a search for mixed Persian/English text

--- a/README.fa.md
+++ b/README.fa.md
@@ -4,6 +4,8 @@
 
 # BidiLens
 
+**نمایش متن ترکیبی فارسی، عربی، عبری و انگلیسی—بدون برعکس‌کردن متن اصلی.**
+
 [![CI](https://github.com/CodeinScrubs/BidiLens/actions/workflows/ci.yml/badge.svg)](https://github.com/CodeinScrubs/BidiLens/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/%40bidilens%2Fcore?color=cb3837&label=npm)](https://www.npmjs.com/package/@bidilens/core)
 [![MIT License](https://img.shields.io/badge/license-MIT-22c55e.svg)](LICENSE)
@@ -11,6 +13,41 @@
 
 [English README](README.md) · [شروع سریع و انتخاب ابزار مناسب (انگلیسی)](docs/GETTING_STARTED.md) · [امنیت](SECURITY.md) ·
 [مشارکت](CONTRIBUTING.md) · [وضعیت پروژه](docs/V1_BUILD_REPORT.md)
+
+## روی یک پیام امتحان کنید
+
+[آزمایش زنده در مرورگر](https://codeinscrubs.github.io/BidiLens/) ·
+[HTML بومی کافی است یا به کتابخانه نیاز دارم؟ (انگلیسی)](docs/NATIVE_OR_BIDILENS.md)
+
+برای React فقط یک بسته نصب کنید:
+
+```sh
+npm install @bidilens/react
+```
+
+```tsx
+import { BidiMessage } from '@bidilens/react';
+
+<BidiMessage
+  text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."
+  inheritedDirection="ltr"
+  style={{ textAlign: 'left' }}
+/>
+```
+
+جهت خواندن این جمله راست‌به‌چپ است، اما عمداً از سمت چپ تراز می‌شود؛
+متن ذخیره‌شده تغییر نمی‌کند. مقدار `inheritedDirection` را مطابق جهت واقعی
+محیط قرار دهید. اگر تراز وابسته به جهت می‌خواهید، استایل `textAlign` را حذف کنید.
+در React Server Components، این کامپوننت را داخل مرز کلاینت قرار دهید.
+برای متن کاملاً انگلیسی در محیط LTR، سیاست پیش‌فرض نشانه‌گذاری جهت و ایزوله‌سازی
+اضافه نمی‌کند. نیازی به تغییر جهت کل برنامه یا نصب همهٔ بسته‌ها نیست.
+
+**وضعیت انتشار:** بسته‌های وب و JavaScript با نسخهٔ `0.4.0` در npm و Android
+با نسخهٔ `0.1.2` در Maven Central منتشر شده‌اند. پیاده‌سازی‌های Swift/iOS،
+.NET/Windows و Rust فعلاً در سطح سورس هستند و انتشار رجیستری محسوب نمی‌شوند.
+
+<details>
+<summary>جزئیات انتشار و شواهد اعتبارسنجی</summary>
 
 > [!IMPORTANT]
 > نسخهٔ `0.4.0` بخش وب و JavaScript برای هر ۱۲ بستهٔ `@bidilens/*` در npm
@@ -27,6 +64,8 @@
 > امضا و checksum و نتیجهٔ آزمون مصرف‌کنندهٔ تمیز از رجیستری عمومی در
 > [انتشار تغییرناپذیر `android-v0.1.2`](https://github.com/CodeinScrubs/BidiLens/releases/tag/android-v0.1.2)
 > ثبت شده‌اند. نسخه‌های پیشین نیز به‌صورت آرشیو تغییرناپذیر در دسترس هستند.
+
+</details>
 
 BidiLens یک ابزار متن‌باز و آفلاین برای نمایش درست متن‌های ترکیبی راست‌به‌چپ
 و چپ‌به‌راست در رابط‌های هوش مصنوعی، Markdown، برنامه‌های وب و Android است.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # BidiLens
 
-**Standards-first mixed RTL/LTR infrastructure for AI interfaces.**
+**Render Persian, Arabic, Hebrew, and English together—without reversing your text.**
 
 [![CI](https://github.com/CodeinScrubs/BidiLens/actions/workflows/ci.yml/badge.svg)](https://github.com/CodeinScrubs/BidiLens/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/%40bidilens%2Fcore?color=cb3837&label=npm)](https://www.npmjs.com/package/@bidilens/core)
@@ -18,10 +18,49 @@
 [Contributing](CONTRIBUTING.md) ·
 [Project status](docs/V1_BUILD_REPORT.md)
 
+## Try it on one message
+
+[Open the live playground](https://codeinscrubs.github.io/BidiLens/) ·
+[See the before/after example](#visual-proof) ·
+[Do I need a library or just native HTML?](docs/NATIVE_OR_BIDILENS.md) ·
+[Documentation index for AI tools](apps/demo/public/llms.txt)
+
+For a React message, install one package:
+
+```sh
+npm install @bidilens/react
+```
+
+```tsx
+import { BidiMessage } from '@bidilens/react';
+
+<BidiMessage
+  text="React یک کتابخانه جاوااسکریپت بسیار محبوب است."
+  inheritedDirection="ltr"
+  style={{ textAlign: 'left' }}
+/>
+```
+
+The Persian paragraph reads RTL while staying aligned to the physical left.
+Your stored text stays unchanged. Set `inheritedDirection` to the actual host
+direction; omit the alignment style if you want direction-aware alignment.
+For React Server Components, put the component in a client boundary.
+
+For English-only content in an LTR host, the default intervention policy does
+not add direction/isolation markup. This is a scoped rendering tool, not a
+global stylesheet, a language model, or a replacement for your design system.
+
 **Adding BidiLens to an existing app?** Follow the
 [integration guide](docs/GETTING_STARTED.md) for one-package setup, copyable
 recipes, compatibility checks, and rollback. You do not need every package
 or a project-wide RTL migration.
+
+**Available today:** JavaScript/web packages on npm (`0.4.0`) and Android on
+Maven Central (`0.1.2`). Swift/iOS, .NET/Windows, and Rust remain source-level
+integrations with separate validation limits; they are not registry releases.
+
+<details>
+<summary>Release provenance and platform validation details</summary>
 
 > [!IMPORTANT]
 > The JavaScript/web `0.4.0` release is public across all 12 `@bidilens/*`
@@ -42,6 +81,8 @@ or a project-wide RTL migration.
 > present in source with dedicated CI gates, but are not yet registry-published
 > or validated in a downstream production/accessibility lab. Other
 > native/desktop platforms remain explicit roadmap work.
+
+</details>
 
 BidiLens is an offline, standards-first toolkit for mixed right-to-left and
 left-to-right text in AI chat, Markdown, streaming interfaces, web, Android,

--- a/apps/demo/public/llms.txt
+++ b/apps/demo/public/llms.txt
@@ -1,0 +1,30 @@
+# BidiLens
+
+> Source-preserving mixed RTL/LTR text tooling for AI chat, Markdown, web, and native integrations. MIT licensed. Offline runtime; no LLM is required.
+
+BidiLens supplies paragraph-direction policy and structural inline isolation.
+The host renderer still performs Unicode bidi layout and glyph shaping.
+Do not reverse source strings or persist display-only Unicode controls.
+Direction, text alignment, and component placement are independent choices.
+The default LTR no-op policy is scoped to LTR hosts without RTL strong characters or bidi formatting controls; it is not a promise of zero runtime cost.
+Content-majority is a heuristic. Preserve explicit caller choices and test ambiguous text in the target renderer.
+JavaScript/web and Android have registry releases. Swift/iOS, .NET/Windows, and Rust are source-level integrations with separate validation limits, not registry releases. Verify current versions in the release records below.
+
+## Start
+
+- [Project overview and release status](https://github.com/CodeinScrubs/BidiLens/blob/main/README.md): Current package and platform availability.
+- [One-message integration guide](https://github.com/CodeinScrubs/BidiLens/blob/main/docs/GETTING_STARTED.md): Choose one adapter, use supported APIs, and retain rollback.
+- [Native HTML or BidiLens?](https://github.com/CodeinScrubs/BidiLens/blob/main/docs/NATIVE_OR_BIDILENS.md): When native markup is enough and how to compose with a UI library.
+- [Persian guide](https://github.com/CodeinScrubs/BidiLens/blob/main/README.fa.md): Persian-language overview and quick start.
+
+## Safety and validation
+
+- [Limitations](https://github.com/CodeinScrubs/BidiLens/blob/main/docs/LIMITATIONS.md): Heuristic, renderer, editor, and platform boundaries.
+- [Accessibility](https://github.com/CodeinScrubs/BidiLens/blob/main/docs/ACCESSIBILITY.md): Source order, assistive technology, and verification limits.
+- [Security](https://github.com/CodeinScrubs/BidiLens/blob/main/docs/SECURITY.md): Bidi-control auditing and untrusted-content handling.
+- [Releases](https://github.com/CodeinScrubs/BidiLens/releases): Published artifacts and provenance. Source on main can be newer than a release.
+
+## Optional
+
+- [Architecture](https://github.com/CodeinScrubs/BidiLens/blob/main/docs/ARCHITECTURE.md): Core analysis and adapter boundaries.
+- [Contribution guide](https://github.com/CodeinScrubs/BidiLens/blob/main/CONTRIBUTING.md): Focused reproductions and contribution checks.

--- a/docs/NATIVE_OR_BIDILENS.md
+++ b/docs/NATIVE_OR_BIDILENS.md
@@ -1,0 +1,71 @@
+# Native HTML or BidiLens?
+
+Use the smallest solution that fits your content. BidiLens complements UI
+components and the browser's Unicode rendering engine; it does not replace them.
+
+| Your situation | Start with |
+|---|---|
+| A known Persian label or paragraph | Explicit `dir="rtl"` and `lang="fa"` on that text boundary |
+| A known English token inside Persian prose | Native `<bdi dir="ltr">` around that token |
+| Unknown text where first-strong direction matches your product policy | Native `dir="auto"` |
+| User/AI prose whose first word may be an English identifier but whose paragraph is Persian | Evaluate BidiLens's content-majority policy, with an explicit caller override |
+| Mixed Markdown, several paragraphs, or streamed messages | A scoped BidiLens adapter plus regression tests in your actual renderer |
+| An LTR-only app that never renders RTL text | You may not need BidiLens at all |
+
+## A native baseline, with no dependency
+
+```html
+<p lang="fa" dir="rtl" style="text-align: left">
+  <bdi dir="ltr">React</bdi> یک کتابخانه جاوااسکریپت بسیار محبوب است.
+</p>
+```
+
+Here the author already knows the paragraph and token directions. Reading
+direction is RTL; physical alignment is left. The DOM text remains in logical
+order. Do not reverse text or persist invisible bidi controls to imitate this.
+
+Native `dir="auto"` uses the first strong directional character, excluding
+isolated descendants such as `<bdi>`; it is not majority-language detection.
+An **unisolated** leading `React` in a plain-text paragraph can therefore
+choose LTR for otherwise Persian prose. The explicit example above avoids
+that ambiguity without a library.
+
+## Where BidiLens helps
+
+Applications cannot always author every paragraph and inline fragment by hand.
+BidiLens provides reusable direction policies, technical-token isolation,
+streaming state, Markdown adapters, and bidi-control auditing. Its default
+policy is a deterministic heuristic, not a semantic oracle: short, balanced,
+or ambiguous text still needs a caller choice or product-specific policy.
+
+Start with the [one-message integration guide](GETTING_STARTED.md). Keep
+direction overrides, preserve logical source, and test both LTR and RTL hosts.
+For an LTR host with no RTL strong characters or bidi formatting controls, the
+default intervention policy emits no direction/isolation markup. This does
+not mean zero execution cost or a universal no-regression guarantee.
+
+## Keep your existing component library
+
+A library such as [PersianLabs UI](https://github.com/persianlabs/ui) supplies
+controls, layout, themes, and Persian-specific UI. BidiLens handles a different
+layer: direction policy and isolation for the text inside those controls.
+Neither replaces the other, and known content may only need native markup.
+
+Keep the avatar, bubble placement, page layout, and design tokens under your
+component library's control. Put a rendering adapter inside the message-content
+boundary, not around the entire application. Text alignment is an independent
+product choice. For block-level adapters, use a container that permits block
+children; do not nest a rendered paragraph inside another `<p>`.
+
+## Before shipping
+
+- Check Persian beginning with Latin text, English containing Persian, pure
+  English, URLs/code, punctuation, and narrow-line wrapping.
+- Check explicit directions and physical left alignment in both host directions.
+- Compare copied text with the original input, including after streamed updates.
+- Test screen readers, selection, and editing/IME in your actual platform.
+- Read [limitations](LIMITATIONS.md), [accessibility guidance](ACCESSIBILITY.md),
+  and [integration/rollback checks](GETTING_STARTED.md).
+
+Terminal glyph shaping and arbitrary editor integration are not automatically
+solved by a web adapter. See the platform-specific guide before selecting one.

--- a/docs/OUTREACH_LOG.md
+++ b/docs/OUTREACH_LOG.md
@@ -392,3 +392,35 @@ have merged native contributions; Hermes and Cline remain submitted without
 human maintainer approval. See the [adoption
 strategy](ADOPTION.md), [limitations](LIMITATIONS.md), and [outreach
 kit](OUTREACH.md) before describing this activity publicly.
+
+## 2026-09-09: invited contribution and adoption follow-up
+
+- **PersianLabs UI:** followed the maintainer's invitation on
+  [issue #84](https://github.com/persianlabs/ui/issues/84) with
+  [PR #95](https://github.com/persianlabs/ui/pull/95). The example composes
+  existing Message/Bubble components with native paragraph direction and inline
+  isolation; no BidiLens dependency or global behavior change is proposed.
+  Local build, typecheck, MDX checks, and three-browser/narrow-width checks passed.
+  Submitted is not merged or adopted; screen-reader/editor/system-clipboard
+  validation is not claimed.
+- **OpenAI Codex:** replied to the new Windows terminal report on
+  [issue #34871](https://github.com/openai/codex/issues/34871#issuecomment-5603956086)
+  with a focused distinction between logical source and terminal rendering, plus
+  chunk-boundary, wrapping, selection, and renderer-specific test suggestions.
+  This was technical follow-up, not a claim that a terminal integration is solved.
+- **BidiLens onboarding:**
+  [PR #90](https://github.com/CodeinScrubs/BidiLens/pull/90) shortens both README
+  quick starts, adds native-versus-toolkit guidance and a documentation index,
+  and asks an optional public-source discovery question on integration requests.
+  No runtime telemetry is introduced; public demo changes still require deployment.
+- **Maintenance:** hardening
+  [PR #89](https://github.com/CodeinScrubs/BidiLens/pull/89) was marked ready after
+  all 25 hosted checks passed. The separate AGP update
+  [PR #86](https://github.com/CodeinScrubs/BidiLens/pull/86#issuecomment-5603956599)
+  remains held: AGP 9.4.0 requires Gradle 9.6.0 or newer, while that branch uses
+  9.5.1. Do not merge it based on unrelated green jobs.
+
+The next priority is feedback on invited/reviewed contributions and bounded
+integration pilots. Star counts and merged native patches are not evidence that
+an upstream project adopted BidiLens as a dependency. Do not send duplicate
+promotional issues or bump unchanged proposals.

--- a/docs/OUTREACH_LOG.md
+++ b/docs/OUTREACH_LOG.md
@@ -424,3 +424,31 @@ The next priority is feedback on invited/reviewed contributions and bounded
 integration pilots. Star counts and merged native patches are not evidence that
 an upstream project adopted BidiLens as a dependency. Do not send duplicate
 promotional issues or bump unchanged proposals.
+
+## 2026-09-13: verified launch claims and targeted introductions
+
+- **PersianLabs:** [PR #95](https://github.com/persianlabs/ui/pull/95) is now
+  merged (September 9). This is a native example contribution, not adoption of
+  BidiLens as a dependency.
+- **Google ADK Web:** shared renderer-specific fixture ideas in
+  [Show and tell #529](https://github.com/google/adk-web/discussions/529).
+  No reproduced ADK defect or agent-runtime change is claimed.
+- **Microsoft Agent Framework:** introduced client-side rendering cases in
+  [Show and tell #8340](https://github.com/microsoft/agent-framework/discussions/8340),
+  explicitly separating DevUI/custom clients from the Python/.NET backend.
+- **Meta Lexical:** shared read-only consumer fixture ideas in
+  [Show and tell #9165](https://github.com/facebook/lexical/discussions/9165),
+  acknowledging existing direction work and avoiding editor DOM mutation.
+
+All three introductions were checked for existing BidiLens discussions and read
+back after publication. Submitted introductions are not maintainer approval,
+pilots, endorsements, or package adoption. GitHub reported 10 stars at this check;
+no new star attribution is established.
+
+External AI launch drafts contained incorrect package/API names, licensing and
+Rust publication claims, plus unverified performance and growth promises. Those
+claims were not used. A fresh Chromium/Firefox/WebKit check confirmed that
+appending Persian after `Hello` does not change `dir=auto` away from LTR, and
+Persian-first RTL text can retain physical left alignment. This focused check is
+not a full-platform validation. No bulk submission script or repeat email blast
+was run.


### PR DESCRIPTION
## Summary

- Put a one-package React quick start, live playground, and clear platform availability at the top of both English and Persian READMEs. Keep the release provenance details available in a collapsible section.
- Add a native-HTML-versus-BidiLens decision guide, including when no library is necessary and how content direction complements a component library such as PersianLabs UI.
- Add a static `llms.txt` documentation index to the demo's public assets, with caller-override, LTR-no-op, release, and validation boundaries.
- Add an optional public-source discovery question to integration requests. No runtime analytics or tracking added.

## Verification

- Frozen-lockfile installation passed; no package or lockfile change.
- Typecheck, lint, and all 479 tests passed on this main-based documentation branch.
- Documentation check passed: 73 Markdown files, 119 local links.
- Core/Markdown/React/Web Component fixture builds and demo production build passed.
- Rendered the quick-start component: source preserved, RTL paragraph with physical left alignment, and isolated React token. English-only/LTR control adds no direction/isolation markup.
- Verified the built `llms.txt` equals the source and every repository-document target exists locally.

No runtime behavior, dependencies, telemetry, or release versions change. Native iOS/Windows/Rust remain source-level integrations; no universal no-regression or semantic-detection claim is made. The index becomes available on the public demo only after merge and a Pages deployment. This branch is independent of hardening PR #89.
