### PR TITLE
feat(core): expand default technical identifiers with modern backend and runtime tools

### DIFF
--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -57,6 +57,12 @@ describe('direction detection', () => {
     expect(detectDirection('React یک کتابخانه است.')).toBe('rtl');
   });
 
+  it('recognizes modern backend and runtime identifiers as technical tokens', () => {
+    const ranges = findTechnicalTokenRanges('اتصال به postgres و redis با bun و deno');
+    expect(ranges.map((range) => range.text)).toEqual(['postgres', 'redis', 'bun', 'deno']);
+    expect(detectDirection('با redis کش کنید.')).toBe('rtl');
+  });
+
   it('keeps hyphenated English compounds as natural-language evidence', () => {
     // A hyphen is ordinary English compounding. Excluding these tokens removes
     // only LTR evidence, which silently biases mixed blocks toward RTL.

--- a/packages/core/src/detect.ts
+++ b/packages/core/src/detect.ts
@@ -35,7 +35,10 @@ export const DEFAULT_TECHNICAL_IDENTIFIERS = Object.freeze([
   'angular', 'astro', 'chrome', 'docker', 'esbuild', 'eslint', 'firefox',
   'kubernetes', 'kubectl', 'nuxt', 'playwright', 'pnpm', 'preact', 'remix',
   'rollup', 'safari', 'stencil', 'storybook', 'tailwind', 'turbopack', 'vite',
-  'vitest'
+  'vitest',
+  'aws', 'azure', 'biome', 'bun', 'cloudflare', 'deno', 'django', 'fastapi',
+  'firebase', 'gcp', 'graphql', 'mongodb', 'mysql', 'ollama', 'postgres',
+  'prisma', 'pytorch', 'redis', 'supabase', 'turborepo'
 ] as const);
 const KNOWN_TECHNICAL_TOKENS = new Set<string>(DEFAULT_TECHNICAL_IDENTIFIERS);
 const CUSTOM_TECHNICAL_IDENTIFIER_CACHE = new WeakMap<readonly string[], ReadonlySet<string>>();


### PR DESCRIPTION
## Summary
Expand DEFAULT_TECHNICAL_IDENTIFIERS in @bidilens/core with modern database, runtime, framework, and cloud identifiers:
- Adds: aws, azure, biome, bun, cloudflare, deno, django, fastapi, firebase, gcp, graphql, mongodb, mysql, ollama, postgres, prisma, pytorch, redis, supabase, turborepo
- Prevents natural-language evidence distortion when mentioning modern technical tooling in Persian/Arabic prose
- Adds unit tests verifying token recognition and RTL direction preservation

## Verification
- Ran vitest: 480 passed (19 test files).
- Ran eslint: 0 errors, 0 warnings.
- Ran tsc typecheck: 0 errors.
