### PR TITLE
feat(core): include all 18 Unicode bidirectional formatting controls in BIDI_CONTROLS

### DIFF
--- a/packages/core/src/controls.ts
+++ b/packages/core/src/controls.ts
@@ -12,7 +12,13 @@ export const BIDI_CONTROLS = Object.freeze({
   LRI: '\u2066',
   RLI: '\u2067',
   FSI: '\u2068',
-  PDI: '\u2069'
+  PDI: '\u2069',
+  ISS: '\u206A',
+  ASS: '\u206B',
+  IAFS: '\u206C',
+  AAFS: '\u206D',
+  NADS: '\u206E',
+  NODS: '\u206F'
 });
 
 const ALL_CONTROLS_RE = /[\u061C\u200E\u200F\u202A-\u202E\u2066-\u206F]/g;

--- a/packages/core/src/core.test.ts
+++ b/packages/core/src/core.test.ts
@@ -16,6 +16,7 @@ import {
   segmentDirectionalRuns,
   findDirectionalRuns,
   stripBidiControls,
+  hasBidiControls,
   findTechnicalTokenRanges,
   needsBidiIntervention,
   planInlineIsolation
@@ -1175,5 +1176,14 @@ describe('security', () => {
     const hidden = report.findings.find((finding) => finding.code === 'HIDDEN_ZERO_WIDTH_SPACE')!;
     expect(hidden.sourceRange.utf16.start).toBe(3);
     expect(hidden.sourceRange.codePoint.start).toBe(2);
+  });
+
+  it('exposes all 18 Unicode bidirectional formatting controls and strips them', () => {
+    const controls = Object.values(BIDI_CONTROLS);
+    expect(controls).toHaveLength(18);
+    for (const ctrl of controls) {
+      expect(hasBidiControls(`a${ctrl}b`)).toBe(true);
+      expect(stripBidiControls(`a${ctrl}b`)).toBe('ab');
+    }
   });
 });


### PR DESCRIPTION
## Summary
Complete the BIDI_CONTROLS dictionary by adding the 6 deprecated Unicode formatting controls:
- Adds ISS (U+206A), ASS (U+206B), IAFS (U+206C), AAFS (U+206D), NADS (U+206E), and NODS (U+206F)
- Aligns BIDI_CONTROLS with CONTROL_METADATA in the security scanner
- Adds test verifying all 18 controls are detected by hasBidiControls and stripped by stripBidiControls

## Verification
- Ran vitest: 480 passed (19 test files).
- Ran eslint: 0 errors, 0 warnings.
- Ran tsc typecheck: 0 errors.
