### PR TITLE
feat(spec): export listBidiLensSchemaIds utility in @bidilens/spec

### DIFF
--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -43,6 +43,11 @@ const schemaById = new Map<string, BidiLensJsonSchema>(
   schemas.map((schema) => [schema.$id, schema])
 );
 
+/** Returns a list of all known schema IDs defined in the specification. */
+export function listBidiLensSchemaIds(): readonly BidiLensSchemaId[] {
+  return Object.values(schemaIds);
+}
+
 export function isBidiLensSchemaId(value: string): value is BidiLensSchemaId {
   return schemaById.has(value);
 }

--- a/packages/spec/src/spec.test.ts
+++ b/packages/spec/src/spec.test.ts
@@ -4,6 +4,7 @@ import { analyzeBlock, createBidiStream, scanBidiSecurity } from '@bidilens/core
 import {
   SPEC_VERSION,
   blockAnalysisSchema,
+  listBidiLensSchemaIds,
   commonSchema,
   getBidiLensSchema,
   indexSchema,
@@ -23,6 +24,13 @@ function validator() {
 }
 
 describe('@bidilens/spec', () => {
+  it('enumerates all schema IDs via listBidiLensSchemaIds()', () => {
+    const ids = listBidiLensSchemaIds();
+    expect(ids).toContain(schemaIds.common);
+    expect(ids).toContain(schemaIds.blockAnalysis);
+    expect(ids.length).toBe(Object.keys(schemaIds).length);
+  });
+
   it('publishes stable, unique, versioned schema identifiers', () => {
     expect(SPEC_VERSION).toBe('0.1.0');
     expect(schemas).toHaveLength(5);


### PR DESCRIPTION
## Summary
Export `listBidiLensSchemaIds()` helper from `@bidilens/spec`:
- Returns an immutable array of all recognized schema URIs defined in the BidiLens specification
- Allows schema registries and validators to enumerate all known schemas programmatically
- Fully covered by unit tests

## Verification
- Added unit test in packages/spec/src/spec.test.ts.
- All checks pass cleanly.
