### PR TITLE
feat(dom): export DEFAULT_BLOCK_SELECTOR and DEFAULT_CODE_SELECTOR in @bidilens/dom

### DIFF
--- a/packages/dom/src/dom.test.ts
+++ b/packages/dom/src/dom.test.ts
@@ -1,8 +1,21 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { applyBidi, installBidiStyles, observeBidi, restoreBidi } from './index.js';
+import {
+  DEFAULT_BLOCK_SELECTOR,
+  DEFAULT_CODE_SELECTOR,
+  applyBidi,
+  installBidiStyles,
+  observeBidi,
+  restoreBidi
+} from './index.js';
 
 describe('DOM adapter', () => {
+  it('exports default selector constants', () => {
+    expect(DEFAULT_BLOCK_SELECTOR).toContain('p');
+    expect(DEFAULT_BLOCK_SELECTOR).toContain('blockquote');
+    expect(DEFAULT_CODE_SELECTOR).toContain('code');
+  });
+
   it('does not mutate an LTR-only scope', () => {
     document.body.innerHTML = '<main id="root"><p class="message">React is popular.</p><pre><code>npm test</code></pre></main>';
     const root = document.querySelector<HTMLElement>('#root')!;

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -30,13 +30,15 @@ bdi {
 }
 `;
 
-const DEFAULT_BLOCK_SELECTOR = [
+/** Default CSS selector for block-level elements scanned by BidiLens. */
+export const DEFAULT_BLOCK_SELECTOR = [
   'p', 'li', 'blockquote', 'dd', 'dt', 'figcaption',
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
   'td', 'th', '[data-bidilens-candidate]'
 ].join(',');
 
-const DEFAULT_CODE_SELECTOR = 'pre, code, kbd, samp, var, [data-bidilens-code]';
+/** Default CSS selector for inline and block code elements isolated by BidiLens. */
+export const DEFAULT_CODE_SELECTOR = 'pre, code, kbd, samp, var, [data-bidilens-code]';
 
 export interface ApplyBidiOptions extends DetectionOptions {
   blockSelector?: string;


### PR DESCRIPTION
## Summary
Export `DEFAULT_BLOCK_SELECTOR` and `DEFAULT_CODE_SELECTOR` constants from `@bidilens/dom`:
- Allows external applications and framework wrappers to inspect, compose, or extend default element selectors without code duplication
- Maintains full backwards compatibility

## Verification
- Added unit tests in packages/dom/src/dom.test.ts.
- All checks pass cleanly.
