### PR TITLE
feat(html): export SAFE_BLOCK_TAGS and SAFE_CONTAINER_TAGS in @bidilens/html

### DIFF
--- a/packages/html/src/html.test.ts
+++ b/packages/html/src/html.test.ts
@@ -1,8 +1,20 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { escapeHtml, renderBidiHtml, renderInlineBidiHtml } from './index.js';
+import {
+  SAFE_BLOCK_TAGS,
+  SAFE_CONTAINER_TAGS,
+  escapeHtml,
+  renderBidiHtml,
+  renderInlineBidiHtml
+} from './index.js';
 
 describe('semantic HTML serializer', () => {
+  it('exports safe block and container tag sets', () => {
+    expect(SAFE_BLOCK_TAGS.has('div')).toBe(true);
+    expect(SAFE_BLOCK_TAGS.has('p')).toBe(true);
+    expect(SAFE_CONTAINER_TAGS.has('article')).toBe(true);
+  });
+
   it('adds no BidiLens markup to ordinary LTR-only input by default', () => {
     const source = 'React is a very popular JavaScript library.';
     const result = renderBidiHtml(source);

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -34,12 +34,14 @@ export interface RenderedBidiHtml {
 }
 
 const SAFE_TAG = /^[a-z][a-z0-9-]*$/u;
-const SAFE_BLOCK_TAGS = new Set([
+/** Whitelisted safe HTML block-level tags. */
+export const SAFE_BLOCK_TAGS: ReadonlySet<string> = new Set([
   'address', 'article', 'aside', 'blockquote', 'dd', 'div', 'dt', 'figcaption',
   'footer', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'li', 'main', 'nav',
   'p', 'pre', 'section', 'span', 'td', 'th'
 ]);
-const SAFE_CONTAINER_TAGS = new Set([
+/** Whitelisted safe HTML container tags. */
+export const SAFE_CONTAINER_TAGS: ReadonlySet<string> = new Set([
   'article', 'aside', 'blockquote', 'div', 'footer', 'header', 'main', 'nav', 'section', 'span'
 ]);
 


### PR DESCRIPTION
## Summary
Export `SAFE_BLOCK_TAGS` and `SAFE_CONTAINER_TAGS` sets from `@bidilens/html`:
- Typed as `ReadonlySet<string>`
- Allows consumers to pre-validate custom tag options before calling `renderBidiHtml()`
- Completely non-breaking

## Verification
- Added unit tests in packages/html/src/html.test.ts.
- All checks pass cleanly.
